### PR TITLE
feat(backend): add Wildfire mongoose model (schema scaffold)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,9 @@ backend/**
 frontend/**
 !backend/__tests__/
 !backend/__tests__/**
+!backend/
+!backend/models/
+!backend/models/Wildfire.js
 # …but allow package manifests so CI can exist without app code:
 !backend/
 !frontend/

--- a/backend/models/Wildfire.js
+++ b/backend/models/Wildfire.js
@@ -1,0 +1,15 @@
+// ignis-ai-backend/models/Wildfire.js
+const mongoose = require('mongoose');
+
+const WildfireSchema = new mongoose.Schema({
+  latitude:   { type: Number, required: true },
+  longitude:  { type: Number, required: true },
+  brightness: { type: Number, required: true },
+  confidence: { type: String, required: true },   // still storing as string
+  satellite:  { type: String, required: true },
+  timestamp:  { type: Date,   required: true }    // now required
+}, {
+  timestamps: false   // you can enable createdAt/updatedAt if you’d like
+});
+
+module.exports = mongoose.model('Wildfire', WildfireSchema);


### PR DESCRIPTION
What
- Add Mongoose schema + model for `Wildfire` (latitude, longitude, brightness, confidence, scan, timestamp).

Why 
- Coding: incremental backend contribution.
- Architecture: establishes data model boundary.

Notes
- Not wired to routes yet (no runtime change).
- Follow-up PR will add a read endpoint + test.