### PR TITLE
Unit Tests for historicalWildfires.js, topography.js

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,12 +6,12 @@ on:
     paths:
       - 'backend/**'
       - 'frontend/**'
-      - '.github/workflows/node.yml'
+      - '.github/workflows/ci.yml'
   pull_request:
     paths:
       - 'backend/**'
       - 'frontend/**'
-      - '.github/workflows/node.yml'
+      - '.github/workflows/ci.yml'
   schedule:
     - cron: '0 9 * * 1' # Weekly schedule at 9:00 UTC on Mondays, could possibly remove if we only want CI running on push/PR
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ on:
       - 'frontend/**'
       - '.github/workflows/node.yml'
   schedule:
-    - cron: '0 9 * * 1'
+    - cron: '0 9 * * 1' # Weekly schedule at 9:00 UTC on Mondays, could possibly remove if we only want CI running on push/PR
 
 jobs:
   backend:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,86 @@
+name: Node CI
+
+on:
+  push:
+    branches: [ main, develop ]
+    paths:
+      - 'backend/**'
+      - 'frontend/**'
+      - '.github/workflows/node.yml'
+  pull_request:
+    paths:
+      - 'backend/**'
+      - 'frontend/**'
+      - '.github/workflows/node.yml'
+  schedule:
+    - cron: '0 9 * * 1'
+
+jobs:
+  backend:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: backend
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '18'
+          cache: 'npm'
+          cache-dependency-path: 'backend/package-lock.json'
+      - run: npm ci
+      - run: npm run lint --if-present
+      # run jest in CI mode; if you configured coverage in jest.config.cjs it will generate ./coverage
+      - run: npm test -- --ci --reporters=default
+      - uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: backend-coverage
+          path: backend/coverage
+          if-no-files-found: ignore
+      - run: npm run build --if-present
+      - uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: backend-build
+          path: backend/**/dist/*
+          if-no-files-found: ignore
+
+  frontend:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: frontend
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '18'
+          cache: 'npm'
+          cache-dependency-path: 'frontend/package-lock.json'
+      - run: npm ci
+      - run: npm run lint --if-present
+      # CRA/jest needs CI=true to avoid watch prompts
+      - run: CI=true npm test -- --watchAll=false
+      - run: npm run build --if-present
+      - uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: frontend-build
+          path: frontend/build
+          if-no-files-found: ignore
+
+  codeql:
+    name: CodeQL
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
+    steps:
+      - uses: actions/checkout@v4
+      - uses: github/codeql-action/init@v3
+        with:
+          languages: javascript
+      - uses: github/codeql-action/autobuild@v3
+      - uses: github/codeql-action/analyze@v3

--- a/backend/__tests__/test_historicalWildfires.js
+++ b/backend/__tests__/test_historicalWildfires.js
@@ -1,0 +1,57 @@
+const express = require('express');
+const request = require('supertest');
+
+// Mock external dependencies used by the route
+jest.mock('axios', () => ({
+  get: jest.fn().mockResolvedValue({ data: '' }), // empty CSV to skip parsing/inserts
+}));
+
+// Route requires csv-parser at module load; provide a harmless mock
+jest.mock('csv-parser', () => () => {
+  const { Transform } = require('stream');
+  // No-op transform; not used in this test because CSV is empty
+  return new Transform();
+});
+
+// Mock the Mongoose model to avoid requiring mongoose
+jest.mock('../models/HistoricalWildfire', () => ({
+  insertMany: jest.fn().mockResolvedValue(undefined),
+}));
+
+describe('GET /historical-wildfires', () => {
+  let app;
+  const axios = require('axios');
+  const Model = require('../models/HistoricalWildfire');
+
+  beforeAll(() => {
+    process.env.NASA_API_KEY = 'test-key';
+    const router = require('../routes/historicalWildfires');
+    app = express();
+    app.use('/', router);
+  });
+
+  it('calls NASA FIRMS per chunk and returns zero totals on empty CSV', async () => {
+    const res = await request(app).get('/historical-wildfires');
+
+    expect(res.status).toBe(200);
+    expect(res.body).toHaveProperty('message');
+    expect(res.body).toHaveProperty('results');
+
+    // Two historical fires, each chunked into 3 ranges (10,10,remaining)
+    expect(axios.get).toHaveBeenCalledTimes(6);
+
+    // No records inserted because CSV was empty for all chunks
+    expect(Model.insertMany).not.toHaveBeenCalled();
+
+    // Validate aggregated results are zero for each fire
+    const results = res.body.results;
+    expect(Array.isArray(results)).toBe(true);
+    expect(results).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ fireName: 'Eaton Fire', totalRecords: 0 }),
+        expect.objectContaining({ fireName: 'Palisades', totalRecords: 0 }),
+      ])
+    );
+  });
+});
+

--- a/backend/__tests__/test_topography.js
+++ b/backend/__tests__/test_topography.js
@@ -1,0 +1,67 @@
+const express = require('express');
+const request = require('supertest');
+
+// Mock external modules used by the route
+jest.mock('canvas', () => {
+  const getContext = () => ({
+    drawImage: jest.fn(),
+    // Ignore x/y and just return constant pixel data so elevation is deterministic
+    getImageData: () => ({ data: [0, 0, 0, 255] }), // elevation => -10000, slope => 0
+  });
+  return {
+    createCanvas: () => ({ getContext }),
+    loadImage: () => Promise.resolve({ width: 5, height: 5 }),
+  };
+});
+
+jest.mock('axios', () => ({
+  post: jest.fn().mockResolvedValue({
+    data: { elements: [{ tags: { landuse: 'forest' } }] },
+  }),
+}));
+
+jest.mock('../models/Topography', () => ({
+  findOneAndUpdate: jest.fn().mockImplementation((filter, update) => {
+    // Echo back a doc resembling what Mongo would return
+    return Promise.resolve({
+      location: update.$set.location,
+      elevation: update.$set.elevation,
+      slope: update.$set.slope,
+      vegetationType: update.$set.vegetationType,
+    });
+  }),
+}));
+
+describe('GET /api/topography', () => {
+  let app;
+
+  beforeAll(() => {
+    // Ensure token is set to avoid route complaining about env var
+    process.env.MAPBOX_ACCESS_TOKEN = 'test-token';
+
+    const router = require('../routes/topography');
+    app = express();
+    app.use('/api/topography', router);
+  });
+
+  it('responds with upserted topography data', async () => {
+    const lat = 12.34;
+    const lon = 56.78;
+
+    const res = await request(app)
+      .get('/api/topography')
+      .query({ lat, lon });
+
+    expect(res.status).toBe(200);
+    expect(res.body.message).toBe('ok');
+
+    // From mocks: elevation = -10000 (all zeros RGB), slope = 0, landuse = 'forest'
+    expect(res.body.data).toMatchObject({
+      location: { type: 'Point', coordinates: [lon, lat] },
+      elevation: -10000,
+      slope: 0,
+      vegetationType: 'forest',
+    });
+  });
+});
+

--- a/e2e/requirements.txt
+++ b/e2e/requirements.txt
@@ -1,0 +1,3 @@
+pytest==8.3.3
+selenium==4.24.0
+webdriver-manager==4.0.2


### PR DESCRIPTION
Implemented Jest unit tests for the aforementioned routes. Tests are executed by Github Actions CI pipeline via `npm test`.

**test_topography.js** 
- Mocks `canvas`
- Mocks `axios.post` to simulate Overpass API returning `landuse: 'forest'`
- Mocks `Topography.findOneAndUpdate` to avoid MongoDB and echo back the upserted doc
- Mounts router on a minimal Express app and asserts a 200 response with expected `data` shape

**test_historicalWildfires.js**
- Mocks `axios.get` to return empty CSV 
- Mounts router and hits `GET /historical-wildfires` endpoint
- Asserts 200 and prescence of `message` and `results`

May need to change `await HistoricalWildfire.insertMany(records);` to `await historicalWildfire.insertMany(records);` in `historicalWildfire.js`.
