### PR TITLE
Added linux/arm64 as a platform for Docker builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -105,6 +105,7 @@ jobs:
           context: ./backend
           file: ./backend/Dockerfile
           push: true
+          platforms: linux/amd64, linux/arm64
           tags: ghcr.io/${{ env.REPO_OWNER_LOWER }}/ignisai-backend:latest
           cache-from: type=gha
           cache-to: type=gha,mode=max


### PR DESCRIPTION
- Added very small change to the Docker build process in ci.yml to include linux/arm64 as a platform to build for, since our EC2 instance uses ARM64 Gravitron2 CPUs