### PR TITLE
test(backend): add wildfires.filters & predictFireSpread.route tests

### DIFF
--- a/backend/__tests__/predictFireSpread.route.test.js
+++ b/backend/__tests__/predictFireSpread.route.test.js
@@ -1,0 +1,66 @@
+// __tests__/predictFireSpread.route.test.js
+jest.mock('axios', () => ({ get: jest.fn() }));
+
+const request = require('supertest');
+const axios   = require('axios');
+const app     = require('../app');
+
+describe('POST /api/predict-fire-spread → tilesvc proxy', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('returns overlay artifacts when tilesvc succeeds', async () => {
+    // Mock tilesvc endpoints
+    axios.get.mockImplementation((url, { params } = {}) => {
+      if (url.includes('/predict_geojson')) {
+        return Promise.resolve({
+          data: {
+            type: 'FeatureCollection',
+            features: [
+              {
+                type: 'Feature',
+                properties: { type: 'spread', probability: 0.4, wind_dir: 180 },
+                geometry: {
+                  type: 'Polygon',
+                  coordinates: [[[0,0],[1,0],[1,1],[0,1],[0,0]]]
+                }
+              }
+            ]
+          }
+        });
+      }
+      if (url.includes('/predict') && params?.png === false) {
+        return Promise.resolve({ data: { area_fraction: 0.42, threshold: 0.5 } });
+      }
+      return Promise.reject(new Error('axios mock: unexpected URL ' + url));
+    });
+
+    const res = await request(app)
+      .post('/api/predict-fire-spread')
+      .send({ lat: 34.05, lon: -118.25, Tseq: 3 })   // send lat + lon explicitly
+      .timeout(5000);
+
+    expect([200, 201]).toContain(res.status);
+    expect(res.body).toMatchObject({
+      ok: true,
+      threshold: expect.any(Number),
+      spread_probability: expect.any(Number),
+      spread_distance_km: expect.any(Number),
+    });
+    expect(res.body.geojson?.type).toBe('FeatureCollection');
+  });
+
+  it('propagates tilesvc errors as 5xx JSON', async () => {
+    // First call to /predict_geojson fails
+    axios.get.mockRejectedValueOnce(new Error('tilesvc down'));
+
+    const res = await request(app)
+      .post('/api/predict-fire-spread')
+      .send({ lat: 34.05, lon: -118.25, Tseq: 3 })
+      .timeout(5000);
+
+    expect([500, 502, 503]).toContain(res.status);
+    expect(res.body).toHaveProperty('error');
+  });
+});

--- a/backend/__tests__/wildfires.filters.test.js
+++ b/backend/__tests__/wildfires.filters.test.js
@@ -1,0 +1,74 @@
+// backend/__tests__/wildfires.filters.test.js
+const request = require('supertest');
+
+// Mock BEFORE requiring app
+jest.mock('axios', () => ({ get: jest.fn() }));
+jest.mock('../models/Wildfire', () => ({ insertMany: jest.fn() }));
+
+const axios = require('axios');
+const Wildfire = require('../models/Wildfire');
+const app = require('../app');
+
+describe('GET /api/wildfires filtering flags', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  // CSV rows:
+  // r1 = likely flare (night, low conf, low FRP, low brightness)
+  // r2 = predictable (bright & confident)
+  // r3 = not predictable (too dim / low confidence)
+  const csv = [
+    'latitude,longitude,bright_ti4,scan,track,acq_date,acq_time,satellite,instrument,confidence,version,bright_ti5,frp,daynight',
+    '34.111,-118.111,329.0,0.5,0.5,2024-01-15,0430,N21,VIIRS,low,2.0,320.0,10.0,N', // flare candidate
+    '34.222,-118.222,345.0,0.5,0.5,2024-01-15,1430,N21,VIIRS,high,2.0,343.0,30.0,D', // predictable
+    '34.333,-118.333,320.0,0.5,0.5,2024-01-15,1500,N21,VIIRS,low,2.0,318.0,15.0,D'   // not predictable
+  ].join('\n');
+
+  test('default behavior excludes likely flares (count = 2)', async () => {
+    axios.get.mockResolvedValue({ data: csv });
+    Wildfire.insertMany.mockResolvedValue([{_id:'x1'},{_id:'x2'}]); // 2 inserts
+
+    const res = await request(app).get('/api/wildfires').expect(200);
+
+    expect(res.body).toHaveProperty('message');
+    expect(res.body).toHaveProperty('count', 2);
+    expect(Wildfire.insertMany).toHaveBeenCalledTimes(1);
+    const docs = Wildfire.insertMany.mock.calls[0][0];
+    expect(Array.isArray(docs)).toBe(true);
+    expect(docs).toHaveLength(2); // flare removed
+  });
+
+  test('excludeFlares=false includes flare (count = 3)', async () => {
+    axios.get.mockResolvedValue({ data: csv });
+    Wildfire.insertMany.mockResolvedValue([{_id:'x1'},{_id:'x2'},{_id:'x3'}]);
+
+    const res = await request(app)
+      .get('/api/wildfires')
+      .query({ excludeFlares: 'false' })
+      .expect(200);
+
+    expect(res.body.count).toBe(3);
+    const docs = Wildfire.insertMany.mock.calls[0][0];
+    expect(docs).toHaveLength(3);
+  });
+
+  test('predictableOnly=true returns only predictable rows (count = 1)', async () => {
+    axios.get.mockResolvedValue({ data: csv });
+    Wildfire.insertMany.mockResolvedValue([{_id:'p1'}]);
+
+    const res = await request(app)
+      .get('/api/wildfires')
+      .query({ predictableOnly: 'true' })
+      .expect(200);
+
+    expect(res.body.count).toBe(1);
+    const docs = Wildfire.insertMany.mock.calls[0][0];
+    expect(docs).toHaveLength(1);
+    // sanity check on derived fields we rely on in UI:
+    expect(docs[0]).toHaveProperty('confidence');
+    expect(typeof docs[0].confidence).toBe('number'); // mapped 0..100
+    expect(docs[0]).toHaveProperty('brightnessCat');  // category present
+    expect(docs[0]).toHaveProperty('predictable', true);
+  });
+});

--- a/backend/app.js
+++ b/backend/app.js
@@ -42,7 +42,16 @@ app.use('/health', require('./routes/health')); // Advanced health with DB check
 // Helper to mount optional routes
 function tryMount(mountPath, modulePath) {
   try {
-    app.use(mountPath, require(modulePath));
+    const mod = require(modulePath);
+    const handler =
+      typeof mod === 'function'
+        ? mod
+        : (mod && typeof mod.default === 'function' ? mod.default : null);
+
+    if (!handler) {
+      throw new Error('argument handler must be a function');
+    }
+    app.use(mountPath, handler);
   } catch (e) {
     console.warn(`Skipping ${modulePath}: ${e.message}`);
   }

--- a/backend/routes/fireData.js
+++ b/backend/routes/fireData.js
@@ -34,10 +34,12 @@ function asConfidencePct(conf) {
 }
 
 // Heuristic to drop likely gas flares
-function isLikelyFlare({ daynight, frp, brightness, confidencePct }) {
+function isLikelyFlare({ daynight, frp, brightness, confidence, confidencePct }) {
+  const conf = Number(confidence ?? confidencePct ?? NaN);
   return (
     daynight === 'N' &&
-    confidencePct <= 60 &&
+    !Number.isNaN(conf) &&
+    conf <= 60 &&
     Number(frp) < 25 &&
     Number(brightness) < 330
   );

--- a/backend/routes/predictFireSpread.js
+++ b/backend/routes/predictFireSpread.js
@@ -110,17 +110,59 @@ router.get('/vector', async (req, res) => {
   }
 });
 
-// POST /api/predict-fire-spread  (back-compat: return vector-style payload)
+// POST /api/predict-fire-spread  (vector-style payload; no self HTTP calls)
 router.post('/', async (req, res) => {
   try {
-    const { lat, lng: lon, Tseq, thr } = req.body || {};
-    if (!lat || !lon) return res.status(400).json({ error: 'lat and lon are required' });
-    const data = await getJSON(
-      new URL('/api/predict-fire-spread/vector', SELF_BASE).toString(),
-      { lat, lon, Tseq: Tseq || 3, thr }, 25000);
-    res.json(data);
+    const b = req.body || {};
+
+    // Accept many common shapes:
+    // { lat, lon } | { lat, lng } | { latitude, longitude }
+    // { location: { lat, lon|lng|latitude|longitude } }
+    const lat =
+      b.lat ??
+      b.latitude ??
+      b.location?.lat ??
+      b.location?.latitude;
+
+    const lon =
+      b.lon ??
+      b.lng ??
+      b.longitude ??
+      b.location?.lon ??
+      b.location?.lng ??
+      b.location?.longitude;
+
+    const Tseq = b.Tseq ?? 3;
+    const thr  = b.thr;
+
+    if (lat == null || lon == null) {
+      return res.status(400).json({ error: 'lat and lon are required' });
+    }
+
+    // 1) GeoJSON polygons from tilesvc
+    const geojson = await getJSON(`${TILE_SVC}/predict_geojson`, { lat, lon, Tseq, thr }, 20000);
+
+    // 2) Meta (area_fraction/threshold) from tilesvc (png=false)
+    let meta = {};
+    try {
+      meta = await getJSON(`${TILE_SVC}/predict`, { lat, lon, Tseq, png: false }, 15000);
+    } catch (_) { meta = {}; }
+
+    const area_fraction = typeof meta?.area_fraction === 'number' ? meta.area_fraction : 0.0;
+    const best_thr = typeof meta?.threshold === 'number' ? meta.threshold : (thr ? Number(thr) : 0.5);
+
+    // Friendly derived field
+    const spread_distance_km = Math.max(0, 64 * Math.sqrt(Math.max(0, area_fraction))); // 64km tile
+
+    return res.json({
+      ok: true,
+      geojson,
+      spread_probability: area_fraction,
+      spread_distance_km,
+      threshold: best_thr
+    });
   } catch (err) {
-    res.status(502).json({ error: 'tilesvc_vector_failed', detail: err.message });
+    return res.status(502).json({ error: 'tilesvc_vector_failed', detail: err.message });
   }
 });
 


### PR DESCRIPTION
Add wildfires.filters.test.js (flare exclusion + predictableOnly flags).
Add predictFireSpread.route.test.js (tilesvc happy/error paths).
Update predictFireSpread.js (vector POST; accepts lat + lon|lng; no self-calls; tolerant meta).
Harden app.js dynamic route mounting.
Improve fireData.js parsing (confidence → pct, flare heuristic, header-only early return).