### PR TITLE
fix(prediction): use Tseq=1 default to match T1 model, add prediction

### DIFF
--- a/backend/routes/predictFireSpread.js
+++ b/backend/routes/predictFireSpread.js
@@ -28,7 +28,7 @@ router.get("/raster", async (req, res) => {
     const params = {
       lat,
       lon,
-      Tseq: Tseq || 3,
+      Tseq: Tseq || 1,
       ...(thr ? { thr } : {}),
       crop_frac: crop_frac != null ? crop_frac : 1.5,
     };
@@ -70,14 +70,14 @@ router.get("/vector", async (req, res) => {
     // 1) GeoJSON polygons from tilesvc (honor thr!)
     const geojson = await getJSON(
       `${TILE_SVC}/predict_geojson`,
-      { lat, lon, Tseq: Tseq || 3, ...(thr ? { thr } : {}), crop_frac: crop },
+      { lat, lon, Tseq: Tseq || 1, ...(thr ? { thr } : {}), crop_frac: crop },
       20000
     );
 
     // 2) Meta (area_fraction + threshold + bounds) from tilesvc
     const meta = await getJSON(
       `${TILE_SVC}/predict`,
-      { lat, lon, Tseq: Tseq || 3, png: false, ...(thr ? { thr } : {}), crop_frac: crop },
+      { lat, lon, Tseq: Tseq || 1, png: false, ...(thr ? { thr } : {}), crop_frac: crop },
       80000
     );
 

--- a/services/tilesvc/app.py
+++ b/services/tilesvc/app.py
@@ -192,6 +192,9 @@ def _predict_probability(lat: float, lon: float, Tseq: int, ignition: bool = Fal
             pass
     prob = np.clip(prob, 0.0, 1.0)
 
+    print(f"🔮 Prediction: min={prob.min():.6f}, max={prob.max():.6f}, "
+          f"mean={prob.mean():.6f}, shape={prob.shape}, Tseq={Tseq}")
+
     return prob, bounds
 
 


### PR DESCRIPTION
The deployed model (Fire_Spread_convlstm_unet_Cd7_Cs15_H128_T1) was trained with T=1 timestep, but the backend defaulted to Tseq=3. This caused the model to receive 3 timesteps when it only trained on 1, producing degraded/zero outputs.

- Change all Tseq defaults from 3 to 1 in predictFireSpread.js
- Add prediction min/max/mean logging to tilesvc app.py for debugging