### PR TITLE
feat: fix 0% predictions, enhance fire visualization 

### DIFF
--- a/backend/routes/predictFireSpread.js
+++ b/backend/routes/predictFireSpread.js
@@ -17,10 +17,10 @@ async function getJSON(url, params = {}, timeout = 80000) {
   return r.data;
 }
 
-// GET /api/predict-fire-spread/raster?lat=&lon=&Tseq=&thr=
+// GET /api/predict-fire-spread/raster?lat=&lon=&Tseq=&thr=&date=
 router.get("/raster", async (req, res) => {
   try {
-    const { lat, lon, Tseq, thr, crop_frac } = req.query;
+    const { lat, lon, Tseq, thr, crop_frac, date } = req.query;
     if (lat == null || lon == null) {
       return res.status(400).json({ error: "lat and lon are required" });
     }
@@ -31,6 +31,7 @@ router.get("/raster", async (req, res) => {
       Tseq: Tseq || 1,
       ...(thr ? { thr } : {}),
       crop_frac: crop_frac != null ? crop_frac : 1.5,
+      ...(date ? { date, ignition: true } : {}),
     };
 
     // tilesvc returns base64 PNG + bounds; crop centers the output on the fire point
@@ -57,27 +58,28 @@ router.get("/raster", async (req, res) => {
   }
 });
 
-// GET /api/predict-fire-spread/vector?lat=&lon=&Tseq=&thr=
+// GET /api/predict-fire-spread/vector?lat=&lon=&Tseq=&thr=&date=
 router.get("/vector", async (req, res) => {
   try {
-    const { lat, lon, Tseq, thr, crop_frac } = req.query;
+    const { lat, lon, Tseq, thr, crop_frac, date } = req.query;
     if (lat == null || lon == null) {
       return res.status(400).json({ error: "lat and lon are required" });
     }
 
     const crop = crop_frac != null ? crop_frac : 0.5;
+    const dateParams = date ? { date, ignition: true } : {};
 
     // 1) GeoJSON polygons from tilesvc (honor thr!)
     const geojson = await getJSON(
       `${TILE_SVC}/predict_geojson`,
-      { lat, lon, Tseq: Tseq || 1, ...(thr ? { thr } : {}), crop_frac: crop },
+      { lat, lon, Tseq: Tseq || 1, ...(thr ? { thr } : {}), crop_frac: crop, ...dateParams },
       20000
     );
 
     // 2) Meta (area_fraction + threshold + bounds) from tilesvc
     const meta = await getJSON(
       `${TILE_SVC}/predict`,
-      { lat, lon, Tseq: Tseq || 1, png: false, ...(thr ? { thr } : {}), crop_frac: crop },
+      { lat, lon, Tseq: Tseq || 1, png: false, ...(thr ? { thr } : {}), crop_frac: crop, ...dateParams },
       80000
     );
 

--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -18,7 +18,7 @@ const DEFAULT_THR =
   (typeof window !== "undefined" &&
     window._env_?.REACT_APP_MODEL_THR &&
     Number(window._env_?.REACT_APP_MODEL_THR)) ||
-  (process.env.REACT_APP_MODEL_THR ? Number(process.env.REACT_APP_MODEL_THR) : 0.10);
+  (process.env.REACT_APP_MODEL_THR ? Number(process.env.REACT_APP_MODEL_THR) : 0.01);
 
 // -----------------------------
 // Existing calls
@@ -33,7 +33,7 @@ export const getWildfireData = (opts = {}) => api.get("/wildfires", { params: op
  * Vector prediction (GeoJSON + spread_probability + environmental_data)
  * Backend expects: /predict-fire-spread/vector?lat=&lon=&thr=
  */
-export const predictFireSpreadVector = async ({ lat, lng, lon, thr, Tseq } = {}) => {
+export const predictFireSpreadVector = async ({ lat, lng, lon, thr, Tseq, date } = {}) => {
   const latitude = lat != null ? Number(lat) : null;
 
   // accept either lng or lon
@@ -52,6 +52,7 @@ export const predictFireSpreadVector = async ({ lat, lng, lon, thr, Tseq } = {})
       lon: longitude,
       thr: threshold,
       ...(Tseq ? { Tseq } : {}),
+      ...(date ? { date } : {}),
     },
   });
 
@@ -62,7 +63,7 @@ export const predictFireSpreadVector = async ({ lat, lng, lon, thr, Tseq } = {})
  * Raster overlay (bounds + image_base64)
  * Backend expects: /predict-fire-spread/raster?lat=&lon=
  */
-export const predictFireSpreadRaster = async ({ lat, lng, lon, thr, Tseq } = {}) => {
+export const predictFireSpreadRaster = async ({ lat, lng, lon, thr, Tseq, date } = {}) => {
   const latitude = lat != null ? Number(lat) : null;
   const longitude =
     lon != null ? Number(lon) : (lng != null ? Number(lng) : null);
@@ -79,6 +80,7 @@ export const predictFireSpreadRaster = async ({ lat, lng, lon, thr, Tseq } = {})
       lon: longitude,
       ...(Tseq ? { Tseq } : {}),
       ...(threshold != null ? { thr: threshold } : {}),
+      ...(date ? { date } : {}),
     },
   });
 
@@ -86,7 +88,7 @@ export const predictFireSpreadRaster = async ({ lat, lng, lon, thr, Tseq } = {})
 };
 
 // Keep your old name if the UI calls it:
-export const predictFireSpread = async ({ lat, lng, thr } = {}) =>
-  predictFireSpreadVector({ lat, lng, thr });
+export const predictFireSpread = async ({ lat, lng, thr, date } = {}) =>
+  predictFireSpreadVector({ lat, lng, thr, date });
 
 export default api;

--- a/frontend/src/components/MapComponent.js
+++ b/frontend/src/components/MapComponent.js
@@ -89,6 +89,15 @@ const pctStr = v => (v == null || Number.isNaN(+v) ? '—' : `${Math.round(+v)}%
 
 const getDirectionName = deg => toCompass(deg);
 
+// ---- Historical fire presets for model testing ----
+const HISTORICAL_FIRES = [
+  { name: 'Camp/Paradise Fire',  date: '2018-11-08', lat: 39.80, lon: -121.44, zoom: 10 },
+  { name: 'Eaton Fire',          date: '2025-01-07', lat: 34.19, lon: -118.06, zoom: 11 },
+  { name: 'Palisades Fire',     date: '2025-01-07', lat: 34.05, lon: -118.55, zoom: 11 },
+  { name: 'Dixie Fire',         date: '2021-07-14', lat: 40.05, lon: -121.38, zoom: 10 },
+  { name: 'Caldor Fire',        date: '2021-08-14', lat: 38.75, lon: -120.30, zoom: 10 },
+];
+
 // ---- Component --------------------------------------------------------------
 const MapComponent = forwardRef(({
   brightnessFilter,
@@ -107,6 +116,11 @@ const MapComponent = forwardRef(({
   const [wildfires, setWildfires]       = useState([]);
   const [isPredicting, setIsPredicting] = useState(false);
   const [activePopup, setActivePopup]   = useState(null);
+
+  // Historical fire testing state
+  const [showHistPanel, setShowHistPanel] = useState(false);
+  const [histDate, setHistDate]           = useState('');
+  const [histRunning, setHistRunning]     = useState(false);
 
   // NDVI overlay state
   const [ndviOn, setNdviOn] = useState(false);
@@ -262,24 +276,24 @@ const MapComponent = forwardRef(({
       const prediction = await predictFireSpread({
         lat: fireProps.latitude,
         lng: fireProps.longitude,
-        thr: 0.1,
+        thr: 0.01,
         Tseq: 1,
       });
 
       // 1) Show a clean raster heatmap overlay (recommended)
-      const thr = 0.1; // lower threshold so mask isn't empty
+      const thr = 0.01;
       const result = await addPredictionOverlay(mapRef.current, {
         apiBase: API_BASE,
         lat: fireProps.latitude,
         lon: fireProps.longitude,
         mode: 'raster',
         thr,
-        floor: 0.15,           // hide tiny probabilities to avoid spotted look
+        floor: 0.01,
         Tseq: 1,
-        gamma: 0.85,
-        opacity: 0.60,
+        gamma: 0.7,
+        opacity: 0.75,
         smooth: true,
-        alphaThreshold: 0.15,
+        alphaThreshold: 0.01,
       });
 
       // Fit to overlay bounds (makes it look “accurate” instead of offset)
@@ -417,8 +431,7 @@ const MapComponent = forwardRef(({
         const map = mapRef.current;
       if (!map) return;
 
-      // Use a default thr that matches your model’s scale (prob_max ~ 0.22)
-      const thr = 0.35;
+      const thr = 0.01;
 
       const result = await addPredictionOverlay(map, {
         apiBase: API_BASE,
@@ -426,13 +439,12 @@ const MapComponent = forwardRef(({
         lon: longitude,
         mode,
         thr,
-        Tseq: 3,
-
-        // Heatmap tuning knobs (optional, but makes it look nicer)
-        gamma: 0.9,
-        floor: 0.2,
-        opacity: 0.6,
-        smooth: true
+        Tseq: 1,
+        gamma: 0.7,
+        floor: 0.01,
+        opacity: 0.75,
+        smooth: true,
+        alphaThreshold: 0.01,
       });
 
       // Fit to tile bounds so overlay doesn’t look “random”
@@ -443,6 +455,77 @@ const MapComponent = forwardRef(({
     } catch (e) {
       console.error('Ignis overlay error:', e);
     }
+  };
+
+  // ---------- Historical fire test ----------
+  const runHistoricalPrediction = async (preset) => {
+    const map = mapRef.current;
+    if (!map || histRunning) return;
+    setHistRunning(true);
+    try {
+      const { lat, lon, date, zoom, name } = preset;
+
+      map.flyTo({ center: [lon, lat], zoom: zoom || 10, duration: 1200 });
+
+      const result = await addPredictionOverlay(map, {
+        apiBase: API_BASE,
+        lat,
+        lon,
+        mode: 'raster',
+        thr: 0.01,
+        Tseq: 1,
+        date,
+        gamma: 0.7,
+        floor: 0.01,
+        opacity: 0.75,
+        smooth: true,
+        alphaThreshold: 0.01,
+      });
+
+      if (result?.bounds) {
+        const [w, s, e, n] = result.bounds;
+        map.fitBounds([[w, s], [e, n]], { padding: 40, duration: 800 });
+      }
+
+      // Show info popup
+      const probMax = result?.meta?.prob_max;
+      const probMean = result?.meta?.prob_mean;
+      const popup = new mapboxgl.Popup()
+        .setLngLat([lon, lat])
+        .setHTML(`
+          <div class="wildfire-popup">
+            <h4>${name}</h4>
+            <div class="prediction-results">
+              <h5>Historical Prediction (${date})</h5>
+              <p><strong>Max probability:</strong> ${probMax != null ? (probMax * 100).toFixed(1) + '%' : '--'}</p>
+              <p><strong>Mean probability:</strong> ${probMean != null ? (probMean * 100).toFixed(2) + '%' : '--'}</p>
+              <p style="margin-top:8px;font-size:0.85em;color:#888;">
+                Uses archived weather data. FIRMS fire detections only available for recent dates;
+                older fires use ignition-point mode.
+              </p>
+            </div>
+          </div>
+        `)
+        .addTo(map);
+      setActivePopup(popup);
+    } catch (e) {
+      console.error('Historical prediction error:', e);
+    } finally {
+      setHistRunning(false);
+    }
+  };
+
+  const runCustomHistorical = async () => {
+    const map = mapRef.current;
+    if (!map || !histDate) return;
+    const center = map.getCenter();
+    await runHistoricalPrediction({
+      name: `Custom (${histDate})`,
+      date: histDate,
+      lat: center.lat,
+      lon: center.lng,
+      zoom: map.getZoom(),
+    });
   };
 
   // ---------- Layers setup ----------
@@ -459,10 +542,38 @@ const MapComponent = forwardRef(({
       type: 'circle',
       source: 'wildfires-source',
       paint: {
-        'circle-radius':       4,
-        'circle-color':        '#FF4500',
-        'circle-stroke-width': 1,
-        'circle-stroke-color': '#fff'
+        'circle-radius': [
+          'match', ['get', 'brightnessCat'],
+          'Extreme', 12,
+          'Severe', 8,
+          'Moderate', 6,
+          4
+        ],
+        'circle-color': [
+          'match', ['get', 'brightnessCat'],
+          'Extreme', '#CC0000',
+          'Severe',  '#FF2200',
+          'Moderate', '#FF6600',
+          '#FFA500'
+        ],
+        'circle-opacity': [
+          'interpolate', ['linear'], ['get', 'confidencePct'],
+          0, 0.4,
+          50, 0.7,
+          100, 1.0
+        ],
+        'circle-stroke-width': [
+          'match', ['get', 'brightnessCat'],
+          'Extreme', 2,
+          'Severe', 1.5,
+          1
+        ],
+        'circle-stroke-color': '#fff',
+        'circle-blur': [
+          'match', ['get', 'brightnessCat'],
+          'Extreme', 0.4,
+          0
+        ]
       }
     });
 
@@ -640,17 +751,79 @@ const MapComponent = forwardRef(({
       .env-data { margin-top: 8px; padding: 8px; background-color: #f8f8f8; border-radius: 4px; font-size: 0.9em; }
       .env-data h6 { margin: 0 0 5px 0; color: #666; }
       .env-data p { margin: 3px 0; }
+      .hist-panel {
+        position: absolute; top: 10px; right: 50px; z-index: 10;
+        background: rgba(30,30,30,0.92); color: #eee;
+        border-radius: 8px; padding: 12px 14px; min-width: 220px;
+        font-size: 13px; box-shadow: 0 2px 12px rgba(0,0,0,0.4);
+      }
+      .hist-panel h4 { margin: 0 0 8px; font-size: 14px; color: #FF6600; }
+      .hist-btn {
+        display: block; width: 100%; padding: 6px 8px; margin: 4px 0;
+        border: none; border-radius: 4px; cursor: pointer;
+        font-size: 12px; font-weight: 600; text-align: left;
+        background: #444; color: #fff;
+      }
+      .hist-btn:hover { background: #666; }
+      .hist-btn:disabled { opacity: 0.5; cursor: wait; }
+      .hist-toggle {
+        position: absolute; top: 10px; right: 10px; z-index: 10;
+        background: #FF6600; color: #fff; border: none; border-radius: 6px;
+        padding: 6px 10px; cursor: pointer; font-size: 13px; font-weight: 700;
+      }
+      .hist-toggle:hover { background: #FF8800; }
     `;
     document.head.appendChild(style);
     return () => { document.head.removeChild(style); };
   }, []);
 
   return (
-    <div
-      ref={mapContainerRef}
-      style={{ width: '100%', height: '100%', position: 'relative' }}
-      title="Press 'N' to toggle NDVI overlay"
-    />
+    <div style={{ width: '100%', height: '100%', position: 'relative' }}>
+      <div
+        ref={mapContainerRef}
+        style={{ width: '100%', height: '100%' }}
+        title="Press 'N' to toggle NDVI overlay"
+      />
+      <button className="hist-toggle" onClick={() => setShowHistPanel(v => !v)}>
+        {showHistPanel ? 'X' : 'History'}
+      </button>
+      {showHistPanel && (
+        <div className="hist-panel">
+          <h4>Historical Fire Testing</h4>
+          <p style={{fontSize:'11px',margin:'0 0 8px',color:'#aaa'}}>
+            Run the model on known historical fires using archived weather.
+          </p>
+          {HISTORICAL_FIRES.map((fire, i) => (
+            <button
+              key={i}
+              className="hist-btn"
+              disabled={histRunning}
+              onClick={() => runHistoricalPrediction(fire)}
+            >
+              {fire.name} ({fire.date})
+            </button>
+          ))}
+          <hr style={{border:'none',borderTop:'1px solid #555',margin:'10px 0'}} />
+          <p style={{fontSize:'11px',margin:'0 0 4px',color:'#aaa'}}>
+            Or pick a custom date (runs prediction at current map center):
+          </p>
+          <input
+            type="date"
+            value={histDate}
+            onChange={e => setHistDate(e.target.value)}
+            style={{width:'100%',padding:'4px',borderRadius:'4px',border:'1px solid #555',background:'#333',color:'#eee',fontSize:'12px'}}
+          />
+          <button
+            className="hist-btn"
+            style={{marginTop:'6px',background:'#FF6600'}}
+            disabled={histRunning || !histDate}
+            onClick={runCustomHistorical}
+          >
+            {histRunning ? 'Running...' : 'Run Custom Date'}
+          </button>
+        </div>
+      )}
+    </div>
   );
 });
 

--- a/frontend/src/utils/addPredictionOverlay.js
+++ b/frontend/src/utils/addPredictionOverlay.js
@@ -88,10 +88,10 @@ function clamp01(x) {
 async function colorizeGrayscalePngToHeatmapDataUrl(base64Png, opts = {}) {
   const {
     gamma = 0.7,
-    floor = 0.18,          // hide low values
-    opacity = 0.60,        // slightly stronger after backend smoothing
+    floor = 0.01,
+    opacity = 0.75,
     smooth = true,
-    alphaThreshold = 0.18, // cut speckle
+    alphaThreshold = 0.01,
   } = opts;
 
   const img = new Image();
@@ -189,7 +189,8 @@ export async function addRasterOverlay(map, apiBase, lat, lon, opts = {}) {
     lat: String(lat),
     lon: String(lon),
     ...(opts.Tseq != null ? { Tseq: String(opts.Tseq) } : { Tseq: "1" }),
-    ...(opts.thr != null ? { thr: String(opts.thr) } : { thr: "0.1" }),
+    ...(opts.thr != null ? { thr: String(opts.thr) } : { thr: "0.01" }),
+    ...(opts.date ? { date: opts.date } : {}),
   });
 
   const url = `${apiBase}/predict-fire-spread/raster?${qs.toString()}`;
@@ -306,7 +307,8 @@ export async function addVectorOverlay(map, apiBase, lat, lon, opts = {}) {
     lat: String(lat),
     lon: String(lon),
     ...(opts.Tseq != null ? { Tseq: String(opts.Tseq) } : { Tseq: "1" }),
-    ...(opts.thr != null ? { thr: String(opts.thr) } : { thr: "0.1" }),
+    ...(opts.thr != null ? { thr: String(opts.thr) } : { thr: "0.01" }),
+    ...(opts.date ? { date: opts.date } : {}),
   });
 
   const url = `${apiBase}/predict-fire-spread/vector?${qs.toString()}`;

--- a/services/tilesvc/app.py
+++ b/services/tilesvc/app.py
@@ -2,6 +2,7 @@ import os
 import io
 import re
 import base64
+import datetime as dt
 from typing import Optional, Tuple, Dict, Any
 
 import numpy as np
@@ -44,7 +45,7 @@ def _get_torch_device() -> torch.device:
 
 DEVICE = _get_torch_device()
 MODEL_PATH = os.getenv("MODEL_PATH", "/models/model.pt")
-MODEL_THRESHOLD = float(os.getenv("MODEL_THRESHOLD", "0.1"))
+MODEL_THRESHOLD = float(os.getenv("MODEL_THRESHOLD", "0.01"))
 
 MODEL_CD = int(os.getenv("MODEL_CD", "7"))
 MODEL_CS = int(os.getenv("MODEL_CS", "15"))
@@ -147,7 +148,24 @@ def _load_model_once():
     return _model
 
 
-def _predict_probability(lat: float, lon: float, Tseq: int, ignition: bool = False) -> Tuple[np.ndarray, Tuple[float, float, float, float]]:
+def _parse_date_param(date_str: Optional[str]) -> Optional[dt.datetime]:
+    if not date_str:
+        return None
+    try:
+        d = dt.datetime.fromisoformat(date_str.replace("Z", "+00:00"))
+        if d.tzinfo is None:
+            d = d.replace(tzinfo=dt.timezone.utc)
+        return d
+    except Exception:
+        # Try simple date format YYYY-MM-DD, default to noon UTC
+        try:
+            d = dt.datetime.strptime(date_str, "%Y-%m-%d")
+            return d.replace(hour=12, tzinfo=dt.timezone.utc)
+        except Exception:
+            return None
+
+
+def _predict_probability(lat: float, lon: float, Tseq: int, ignition: bool = False, ref_time: Optional[dt.datetime] = None) -> Tuple[np.ndarray, Tuple[float, float, float, float]]:
     """
     Returns:
       prob (H,W) in [0,1]
@@ -158,7 +176,7 @@ def _predict_probability(lat: float, lon: float, Tseq: int, ignition: bool = Fal
     # build_grid returns (tile, affine, bounds)
     tile, _, bounds = build_grid(lat, lon)
 
-    dyn = build_dynamic_for_tile(lat, lon, T_seq=Tseq, ignition=ignition)
+    dyn = build_dynamic_for_tile(lat, lon, T_seq=Tseq, ignition=ignition, ref_time=ref_time)
 
     # Load per-tile static rasters and stack into channel-first array.
     stat_dict = load_static_for_tile(tile)
@@ -340,8 +358,10 @@ def predict_png(
     thr: float = Query(None),
     crop_frac: float = Query(1.0),
     ignition: bool = Query(False),
+    date: str = Query(None),
 ):
-    prob, bounds = _predict_probability(lat, lon, Tseq=Tseq, ignition=ignition)
+    ref_time = _parse_date_param(date)
+    prob, bounds = _predict_probability(lat, lon, Tseq=Tseq, ignition=ignition, ref_time=ref_time)
     prob, bounds = _crop_prob_around_point(prob, bounds, lat, lon, crop_frac)
     # Optional threshold override for meta only
     threshold = float(thr) if thr is not None else MODEL_THRESHOLD
@@ -363,8 +383,9 @@ def predict_png(
 
 
 @app.get("/predict_raster")
-def predict_raster_png(lat: float = Query(...), lon: float = Query(...), Tseq: int = Query(1)):
-    prob, bounds = _predict_probability(lat, lon, Tseq=Tseq)
+def predict_raster_png(lat: float = Query(...), lon: float = Query(...), Tseq: int = Query(1), date: str = Query(None)):
+    ref_time = _parse_date_param(date)
+    prob, bounds = _predict_probability(lat, lon, Tseq=Tseq, ref_time=ref_time)
     png = _prob_to_png(prob)
     headers = {"X-Bounds": ",".join(map(str, bounds))}
     return Response(content=png, media_type="image/png", headers=headers)
@@ -378,8 +399,10 @@ def predict_raster_json(
     thr: float = Query(None),
     crop_frac: float = Query(0.5),
     ignition: bool = Query(False),
+    date: str = Query(None),
 ):
-    prob, bounds = _predict_probability(lat, lon, Tseq=Tseq, ignition=ignition)
+    ref_time = _parse_date_param(date)
+    prob, bounds = _predict_probability(lat, lon, Tseq=Tseq, ignition=ignition, ref_time=ref_time)
     prob, bounds = _crop_prob_around_point(prob, bounds, lat, lon, crop_frac)
     threshold = float(thr) if thr is not None else MODEL_THRESHOLD
     png = _prob_to_png(prob, threshold=threshold)
@@ -402,16 +425,19 @@ def predict_geojson(
     thr: float = Query(None),
     crop_frac: float = Query(0.5),
     ignition: bool = Query(False),
+    date: str = Query(None),
 ):
-    prob, bounds = _predict_probability(lat, lon, Tseq=Tseq,  ignition=ignition)
+    ref_time = _parse_date_param(date)
+    prob, bounds = _predict_probability(lat, lon, Tseq=Tseq, ignition=ignition, ref_time=ref_time)
     prob, bounds = _crop_prob_around_point(prob, bounds, lat, lon, crop_frac)
     threshold = float(thr) if thr is not None else MODEL_THRESHOLD
     gj = _prob_to_geojson(prob, bounds, threshold=threshold)
     return JSONResponse(content=gj)
 
 @app.get("/predict_raster_json_raw")
-def predict_raster_json_raw(lat: float = Query(...), lon: float = Query(...), Tseq: int = Query(1), ignition: bool = Query(True)):
-    prob, bounds = _predict_probability(lat, lon, Tseq=Tseq, ignition=ignition)
+def predict_raster_json_raw(lat: float = Query(...), lon: float = Query(...), Tseq: int = Query(1), ignition: bool = Query(True), date: str = Query(None)):
+    ref_time = _parse_date_param(date)
+    prob, bounds = _predict_probability(lat, lon, Tseq=Tseq, ignition=ignition, ref_time=ref_time)
 
     # IMPORTANT: no threshold here
     png = _prob_to_png(prob, threshold=None)

--- a/services/tilesvc/dynamic_builder.py
+++ b/services/tilesvc/dynamic_builder.py
@@ -136,30 +136,74 @@ def _rasterize_fire(points, t_start, t_end, affine):
 
 
 # ---------------- Weather (Open-Meteo) ----------------
-def _fetch_weather(lat: float, lon: float):
-    """
-    Fetch current weather and expand to per-pixel constant grids.
+OPEN_METEO_ARCHIVE = "https://archive-api.open-meteo.com/v1/archive"
 
-    We request **m/s** winds and °C so they match training-time transforms.
-    """
-    params = {
-        "latitude": lat,
-        "longitude": lon,
-        "timezone": "UTC",
-        "current": (
-            "temperature_2m,relative_humidity_2m,"
-            "wind_speed_10m,wind_direction_10m,wind_gusts_10m,precipitation"
-        ),
-        "windspeed_unit": "ms",
-        "precipitation_unit": "mm",
-        "temperature_unit": "celsius",
-    }
 
-    try:
-        j = requests.get(OPEN_METEO, params=params, timeout=12).json()
-        cur = j.get("current", {}) or {}
-    except Exception:
-        cur = {}
+def _fetch_weather(lat: float, lon: float, ref_time: dt.datetime = None):
+    """
+    Fetch weather and expand to per-pixel constant grids.
+    If ref_time is provided and in the past (>24h ago), use the Open-Meteo Archive API.
+    Otherwise use the current/forecast API.
+    """
+    now = dt.datetime.now(dt.timezone.utc)
+    use_archive = (ref_time is not None and (now - ref_time).total_seconds() > 86400)
+
+    cur = {}
+
+    if use_archive:
+        date_str = ref_time.strftime("%Y-%m-%d")
+        target_hour = ref_time.hour
+        params = {
+            "latitude": lat,
+            "longitude": lon,
+            "start_date": date_str,
+            "end_date": date_str,
+            "hourly": (
+                "temperature_2m,relative_humidity_2m,"
+                "wind_speed_10m,wind_direction_10m,wind_gusts_10m,precipitation"
+            ),
+            "windspeed_unit": "ms",
+            "precipitation_unit": "mm",
+            "temperature_unit": "celsius",
+            "timezone": "UTC",
+        }
+        try:
+            j = requests.get(OPEN_METEO_ARCHIVE, params=params, timeout=20).json()
+            hourly = j.get("hourly", {}) or {}
+            times = hourly.get("time", [])
+            # Find the closest hour index
+            idx = min(target_hour, len(times) - 1) if times else 0
+            cur = {
+                "temperature_2m": hourly.get("temperature_2m", [15.0])[idx],
+                "relative_humidity_2m": hourly.get("relative_humidity_2m", [50.0])[idx],
+                "wind_speed_10m": hourly.get("wind_speed_10m", [3.0])[idx],
+                "wind_direction_10m": hourly.get("wind_direction_10m", [0.0])[idx],
+                "wind_gusts_10m": hourly.get("wind_gusts_10m", [3.0])[idx],
+                "precipitation": hourly.get("precipitation", [0.0])[idx],
+            }
+            print(f"[tilesvc] Archive weather for {date_str} hour {target_hour}: T={cur.get('temperature_2m')}, "
+                  f"RH={cur.get('relative_humidity_2m')}, WS={cur.get('wind_speed_10m')}")
+        except Exception as e:
+            print(f"⚠️  Archive weather fetch failed: {e}")
+            cur = {}
+    else:
+        params = {
+            "latitude": lat,
+            "longitude": lon,
+            "timezone": "UTC",
+            "current": (
+                "temperature_2m,relative_humidity_2m,"
+                "wind_speed_10m,wind_direction_10m,wind_gusts_10m,precipitation"
+            ),
+            "windspeed_unit": "ms",
+            "precipitation_unit": "mm",
+            "temperature_unit": "celsius",
+        }
+        try:
+            j = requests.get(OPEN_METEO, params=params, timeout=12).json()
+            cur = j.get("current", {}) or {}
+        except Exception:
+            cur = {}
 
     # Fallbacks if anything missing
     T  = float(cur.get("temperature_2m",       15.0))  # °C
@@ -173,7 +217,6 @@ def _fetch_weather(lat: float, lon: float):
     u, v = wind_to_uv(np.array(WS, np.float32), np.array(WD, np.float32))
     q = rh_to_q(np.array(RH, np.float32), np.array(T, np.float32))
 
-
     H = W = SIZE
     return {
         "u":      np.full((H, W), u, np.float32),
@@ -186,12 +229,16 @@ def _fetch_weather(lat: float, lon: float):
 
 
 # ---------------- Public API ----------------
-def build_dynamic_for_tile(lat: float, lon: float, T_seq: int = 1, hours_step: int = 24, ignition: bool = False):
+def build_dynamic_for_tile(lat: float, lon: float, T_seq: int = 1, hours_step: int = 24, ignition: bool = False, ref_time: dt.datetime = None):
     """
     Build dynamic tensor for the tile containing (lat,lon).
 
     Returns `x_dyn` with shape [T, 7, SIZE, SIZE]
     channels = [fire_t, u, v, gust, tempC, q, precip]
+
+    If ref_time is provided, uses historical weather from that date.
+    FIRMS data is only available for recent dates (1-5 days); for older dates
+    the fire channel will be empty unless ignition=True.
     """
     tile = lonlat_to_tile(lon, lat)
     A    = tile_affine(tile)
@@ -205,7 +252,9 @@ def build_dynamic_for_tile(lat: float, lon: float, T_seq: int = 1, hours_step: i
     print(f"[tilesvc] FIRMS points for tile {tile}: {len(points)} over {days}d window")
 
     # Build T slices: newest last
-    now = dt.datetime.now(dt.timezone.utc).replace(minute=0, second=0, microsecond=0)
+    now = ref_time or dt.datetime.now(dt.timezone.utc).replace(minute=0, second=0, microsecond=0)
+    if ref_time:
+        print(f"[tilesvc] Using historical ref_time: {ref_time.isoformat()}")
     fire_stack = []
     for k in range(T_seq, 0, -1):
         t_end = now - dt.timedelta(hours=(k - 1) * hours_step)
@@ -214,14 +263,14 @@ def build_dynamic_for_tile(lat: float, lon: float, T_seq: int = 1, hours_step: i
         # match train-time boost so sparse points carry signal
         fire_stack.append(fire_boost(m, scale=5.0))
     fire_stack = np.stack(fire_stack, axis=0).astype(np.float32)  # [T,H,W]
-    
+
     if ignition:
         ign = _rasterize_ignition_point(lat, lon, A)      # [H,W] in 5070 meters
         ign = fire_boost(ign, scale=5.0)                  # match train-time boost
         # Inject into the most recent timestep (last index)
         fire_stack[-1] = np.maximum(fire_stack[-1], ign).astype(np.float32)
-    # Weather (constant over the tile for now)
-    wx = _fetch_weather(lat, lon)
+    # Weather (constant over the tile for now; uses archive for historical dates)
+    wx = _fetch_weather(lat, lon, ref_time=ref_time)
 
     # Assemble dynamic tensor
     dyn = []


### PR DESCRIPTION
- Lower all prediction thresholds from 0.1-0.35 to 0.01 across the full stack (tilesvc MODEL_THRESHOLD, frontend DEFAULT_THR, MapComponent hardcoded values, addPredictionOverlay colorizer floor/alphaThreshold) so the model's 5-6% signal is actually visible instead of being filtered to zero

- Enhance wildfire dot visualization with data-driven Mapbox styling: brightness-based circle size (Small=4, Moderate=6, Severe=8, Extreme=12), brightness-based color gradient (orange to deep red), confidence-based opacity, and glow effect for Extreme fires

- Add historical fire testing: new date parameter flows through frontend -> backend -> tilesvc. Dynamic builder uses Open-Meteo Archive API for historical weather when a past date is provided. Includes ignition-point mode for dates beyond FIRMS coverage.

- Add Historical Fire Testing panel to map with preset buttons for known fires (Camp/Paradise 2018, Eaton 2025, Palisades 2025, Dixie 2021, Caldor 2021) and custom date picker that runs prediction at current map center