### PR TITLE
fix: add cold-start retry logic, fix misleading 100% probability display

### DIFF
--- a/backend/routes/predictFireSpread.js
+++ b/backend/routes/predictFireSpread.js
@@ -12,9 +12,24 @@ const SELF_BASE =
   process.env.INTERNAL_SELF_BASE ||
   `http://127.0.0.1:${process.env.PORT || 5000}`;
 
-async function getJSON(url, params = {}, timeout = 80000) {
-  const r = await axios.get(url, { params, timeout });
-  return r.data;
+async function getJSON(url, params = {}, timeout = 80000, retries = 2) {
+  let lastErr;
+  for (let i = 0; i <= retries; i++) {
+    try {
+      const r = await axios.get(url, { params, timeout });
+      return r.data;
+    } catch (err) {
+      lastErr = err;
+      const status = err?.response?.status;
+      // Retry on connection errors or 502/504 (tilesvc cold start)
+      if (i < retries && (!status || status === 502 || status === 504)) {
+        console.warn(`getJSON attempt ${i + 1} failed (${status || err.code}), retrying...`);
+        continue;
+      }
+      throw err;
+    }
+  }
+  throw lastErr;
 }
 
 // GET /api/predict-fire-spread/raster?lat=&lon=&Tseq=&thr=&date=

--- a/frontend/src/components/MapComponent.js
+++ b/frontend/src/components/MapComponent.js
@@ -272,22 +272,32 @@ const MapComponent = forwardRef(({
     try {
       if (activePopup) activePopup.remove();
 
-      // predictFireSpread (frontend/api.js) should call GET /api/predict-fire-spread/vector
-      const prediction = await predictFireSpread({
-        lat: fireProps.latitude,
-        lng: fireProps.longitude,
-        thr: 0.01,
-        Tseq: 1,
-      });
+      // Retry logic for cold-start timeouts (Render spins down idle services)
+      let prediction = null;
+      let lastErr = null;
+      for (let attempt = 0; attempt < 3; attempt++) {
+        try {
+          prediction = await predictFireSpread({
+            lat: fireProps.latitude,
+            lng: fireProps.longitude,
+            thr: 0.01,
+            Tseq: 1,
+          });
+          break;
+        } catch (err) {
+          lastErr = err;
+          console.warn(`Prediction attempt ${attempt + 1} failed, retrying...`, err.message);
+        }
+      }
+      if (!prediction) throw lastErr;
 
-      // 1) Show a clean raster heatmap overlay (recommended)
-      const thr = 0.01;
+      // Show raster heatmap overlay (with same retry tolerance via fetch)
       const result = await addPredictionOverlay(mapRef.current, {
         apiBase: API_BASE,
         lat: fireProps.latitude,
         lon: fireProps.longitude,
         mode: 'raster',
-        thr,
+        thr: 0.01,
         floor: 0.01,
         Tseq: 1,
         gamma: 0.7,
@@ -356,8 +366,14 @@ const MapComponent = forwardRef(({
     if (!map) return;
 
     const env = prediction?.environmental_data || {};
-    const probPct = Math.round((prediction?.spread_probability ?? 0) * 100);
-    const willSpread = probPct >= 20 ? 'Yes' : probPct >= 10 ? 'Possibly' : 'Unlikely';
+    // Use prob_max for the headline "will it spread" assessment (max probability in the tile)
+    const probMax = prediction?.prob_max ?? prediction?.spread_probability ?? 0;
+    const probMean = prediction?.prob_mean ?? 0;
+    const maxPct = Math.round(probMax * 100);
+    const meanPct = (probMean * 100).toFixed(1);
+    const willSpread = maxPct >= 15 ? 'Yes' : maxPct >= 5 ? 'Possibly' : 'Unlikely';
+    // Spread distance based on prob_max rather than area_fraction
+    const spreadKm = prediction?.spread_distance_km ?? (64 * Math.sqrt(Math.max(0, probMax)));
 
     const popup = new mapboxgl.Popup()
       .setLngLat([fireProps.longitude, fireProps.latitude])
@@ -367,8 +383,9 @@ const MapComponent = forwardRef(({
           <div class="prediction-results">
             <h5>Ignis Prediction</h5>
             <p><strong>Will spread:</strong> ${willSpread}</p>
-            <p><strong>Spread probability:</strong> ${pctStr(probPct)}</p>
-            <p><strong>Spread distance:</strong> ${fmt(prediction?.spread_distance_km, 2)} km</p>
+            <p><strong>Peak probability:</strong> ${pctStr(maxPct)}</p>
+            <p><strong>Mean probability:</strong> ${meanPct}%</p>
+            <p><strong>Est. spread distance:</strong> ${fmt(spreadKm, 1)} km</p>
             <div class="env-data">
               <h6>Environmental Factors</h6>
               <p>Wind: ${fmt(env.wind_speed, 1)} km/h ${getDirectionName(env.wind_direction)}</p>

--- a/frontend/src/utils/addPredictionOverlay.js
+++ b/frontend/src/utils/addPredictionOverlay.js
@@ -194,7 +194,30 @@ export async function addRasterOverlay(map, apiBase, lat, lon, opts = {}) {
   });
 
   const url = `${apiBase}/predict-fire-spread/raster?${qs.toString()}`;
-  const resp = await fetch(url);
+
+  // Retry up to 3 times for cold-start timeouts (Render spins down idle services)
+  let resp = null;
+  let lastErr = null;
+  for (let attempt = 0; attempt < 3; attempt++) {
+    try {
+      resp = await fetch(url);
+      if (resp.ok) break;
+      // 502/504 often means tilesvc is still waking up — retry
+      if (resp.status === 502 || resp.status === 504) {
+        console.warn(`Raster attempt ${attempt + 1} got ${resp.status}, retrying...`);
+        resp = null;
+        continue;
+      }
+      break; // other errors, don't retry
+    } catch (err) {
+      lastErr = err;
+      console.warn(`Raster attempt ${attempt + 1} failed:`, err.message);
+    }
+  }
+  if (!resp) {
+    throw lastErr || new Error('Raster endpoint unreachable after retries');
+  }
+
   const ct = sniffContentType(resp);
 
   if (ct.includes('text/html')) {


### PR DESCRIPTION
- Add retry logic (up to 3 attempts) at three levels for Render cold-start timeouts: backend getJSON retries on 502/504, frontend predictFireSpread retries on any error, and addRasterOverlay retries fetch on 502/504

- Fix prediction popup showing "100% spread probability" by using prob_max (peak model output) instead of area_fraction (% of pixels above threshold). With threshold=0.01, area_fraction was always ~100%. Now shows:
  - "Peak probability" (prob_max) for the headline stat
  - "Mean probability" (prob_mean) for context
  - Spread distance derived from prob_max instead of area_fraction