### PR TITLE
v4: self-contained Santa-Ana retrain pipeline 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -88,3 +88,10 @@ models/*.onnx
 *.tif
 *.tiff
 *.vrt
+
+# v4 retrain bulk data (lives on external drive via IGNIS_DATA_ROOT)
+data/tssatfire_raw/
+data/tssatfire_500m_T6/
+data/mNDWS_500m_T6/
+data/perimeters/
+models/eval/

--- a/docs/STORAGE.md
+++ b/docs/STORAGE.md
@@ -1,0 +1,62 @@
+# Moving IgnisAI's data to an external drive
+
+You have ~15 GB free internally and the v4 retrain needs ~70 GB raw + ~100 GB of
+processed tiles. **You do not need to move the project or rewire anything** — the
+code already centralizes paths, and v4 adds one env var so the big files live on
+the external drive while the code stays in `~/Downloads/IgnisAI`.
+
+## Recommended: keep code where it is, put data on the drive
+
+1. Plug in the 1 TB drive. On a Mac it mounts at `/Volumes/<DriveName>`.
+2. Make a folder for the data:
+   ```bash
+   mkdir -p /Volumes/<DriveName>/ignis-data
+   ```
+3. Point IgnisAI at it (add to `~/.zshrc` so it sticks across terminals):
+   ```bash
+   export IGNIS_DATA_ROOT=/Volumes/<DriveName>/ignis-data
+   ```
+4. That's it. Everything that reads/writes large data now uses that path:
+   - TS-SatFire download target: `$IGNIS_DATA_ROOT/tssatfire_raw/`
+   - Processed tiles: `$IGNIS_DATA_ROOT/tssatfire_500m_T6/`
+   - Trained checkpoints + calibration: `$IGNIS_DATA_ROOT/models/`
+   - mNDWS tiles (if you also move them): `$IGNIS_DATA_ROOT/mNDWS_500m_T6/`
+
+How it works: `ignis_ml/src/utils/paths.py` resolves a data root from
+`IGNIS_DATA_ROOT` (falling back to `<repo>/data`), and any config path that
+starts with `data/` is rebased onto it. The ingestion script, `train_v4.py`, and
+`run_v4.sh` all use it. Set `IGNIS_MODELS_ROOT` too if you want checkpoints
+somewhere other than `<data_root>/models`.
+
+So your sequence is:
+```bash
+export IGNIS_DATA_ROOT=/Volumes/<DriveName>/ignis-data
+kaggle datasets download -d z789456sx/ts-satfire \
+  -p "$IGNIS_DATA_ROOT/tssatfire_raw" --unzip
+./run_v4.sh
+```
+
+The internal disk only holds the small code repo; the 70–100 GB never touches it.
+
+## Alternative: move the entire project to the drive
+
+Also fine and needs no rewiring (all in-repo paths are relative):
+```bash
+cp -R ~/Downloads/IgnisAI /Volumes/<DriveName>/IgnisAI
+```
+Then re-open the project from its new location and run everything from there. Trade-offs vs. the env-var approach:
+- The whole repo (and git history) lives on the external drive, so the drive must
+  be connected to do anything, and git/IO go over USB.
+- With the env-var approach the code stays on your fast internal SSD and only the
+  bulk data is external — generally the nicer setup.
+
+## Caveats
+
+- **Keep the drive plugged in** during ingestion and training.
+- **Filesystem:** APFS or Mac OS Extended is ideal. exFAT works for storing data
+  but doesn't do POSIX symlinks/permissions well — fine here since we use real
+  folders, not symlinks.
+- **Speed:** USB-3/Thunderbolt is plenty for this workload; training reads tiles
+  in DataLoader workers, not in a tight latency-bound loop.
+- **Don't commit the data:** it lives outside the repo (or under `data/`, which is
+  gitignored), so it won't bloat git.

--- a/docs/heatmap-diagnosis.md
+++ b/docs/heatmap-diagnosis.md
@@ -1,0 +1,148 @@
+# IgnisAI — Fire-Spread Heatmap Diagnosis (June 2026)
+
+Root-cause analysis of why the fire-spread heatmap (live and historical) is
+inaccurate, based on a live walkthrough of the deployed app plus a code audit of
+`ignis_ml/`, `services/tilesvc/`, and `frontend/`.
+
+This complements `docs/v4-retraining-gameplan.md` (which is correct and remains
+the plan). This file is the *evidence* behind that plan plus two issues the
+gameplan did not call out.
+
+---
+
+## TL;DR
+
+The heatmap is wrong for **three independent reasons**, in priority order:
+
+1. **The model (v3) is the core problem — needs retraining.** Trained on mNDWS
+   (next-day, 500 m, 2012–2020 summer/fall vegetated-mountain CONUS fires), it is
+   out-of-distribution for a January coastal Santa-Ana WUI fire like Palisades.
+   Two training choices actively suppress the signal that drives such fires
+   (wind dropout) and inject a spurious one (urban shortcut features). Reported
+   quality is CSI ≈ 0.235 — weak.
+2. **The multistep rollout amplifies the weakness (fixable without retraining).**
+   The autoregressive feedback is a monotonic `max()` ratchet that only adds
+   probability mass and never lets it decay, so the field diffuses and confidence
+   decays across the 6-day timeline. It also re-fetches weather *per step*, which
+   is why multistep times out (>180 s) while single-step raster returns in ~18 s.
+3. **The renderer makes it look mushy (fully fixable now).** The heatmap PNG is
+   2× upscaled with image smoothing (the soft-blob blur), alpha ramps from a 0.3
+   floor (so trivial probabilities still show), and the crisp contour outline
+   layers are never populated for the timeline.
+
+The tight, *accurate*, directional Palisades spread requires fixing #1. #2 and #3
+make the current output cleaner and faster but cannot manufacture spread the
+model didn't predict.
+
+---
+
+## Evidence from the live app (Palisades historical preset)
+
+Ran History → Historical Fire Testing → "Palisades Fire (2025-01-07 10:30 PT)".
+The forecast returned 6 frames. Per-frame numbers off the timeline panel:
+
+| Frame (day) | Peak advisory prob | Above 95% decision thr | Visible cells (floor 10%) | Next-fire area |
+| --- | --- | --- | --- | --- |
+| 1 | 90.5% | **0.0%** | 5.5% | 0.9% |
+| 2 | 82.7% | **0.0%** | 12.5% | 0.9% |
+| 3 | 72.9% | **0.0%** | 11.6% | 0.9% |
+| 6 | 79.3% | **0.0%** | 4.8% | 0.9% |
+
+Observations:
+
+- **Never crosses its own decision threshold.** Peak ≈ 90% < 95% threshold, so
+  "above decision threshold" is 0.0% on *every* frame. The displayed heatmap is
+  entirely sub-threshold mass shown only because `display_floor = 0.1`.
+- **Confidence decays and area diffuses** over the timeline (90.5 → 82.7 → 72.9%),
+  the opposite of the real fire, which *accelerated* (14,500 acres on Jan 8).
+- **Mislocated.** The prediction crop window sits around San Vicente Mountain;
+  the real catastrophic spread went SW/S to the Pacific Palisades neighborhoods
+  and coast — outside the predicted footprint — then north.
+
+Compared against the NASA/observed Jan 7–12 progression, the app matches on
+**none** of: footprint, direction, magnitude, or temporal acceleration.
+
+### Infra notes seen live
+
+- `GET /api/predict-fire-spread/multistep` hangs and the frontend logs
+  `safety-net timeout fired … Forecast timed out after 180s` (it retries 5×).
+- `/health` returns `DEGRADED`, `tilesvc: disconnected` — but tilesvc is actually
+  reachable server-side (single-step `/raster` returned 200 in ~18 s). The
+  `disconnected` flag comes from a too-aggressive 2.5 s `healthz` probe against a
+  CPU service plus `TILE_SVC` env fragility (defaults to `http://localhost:8008`
+  if unset; render.yaml marks it `sync:false`).
+
+---
+
+## Code-level root causes
+
+### 1. Model / training (`ignis_ml/`)
+
+- **Dataset mismatch.** `config.yaml` → `datasets.mndws` (Next-Day Wildfire
+  Spread). No Santa-Ana coastal fires in distribution.
+- **Wind is dropped during training.** `augmentation.channel_dropout_p: 0.15`
+  zeroes non-fire dynamic channels — including `u`, `v`, `gust` — ~15% of the
+  time (`dataset.py::_augment`). The model learns wind is optional and
+  under-weights it at inference. For Santa-Ana fires wind is *the* driver.
+- **Urban shortcut features.** Static `impervious` and `population` light up on
+  California WUI tiles and the model uses them as a shortcut, pulling predictions
+  toward the urban edge / I-405 band regardless of wind/terrain.
+- **Tversky is configured but never applied.** `config.yaml` enables
+  `loss.tversky` (alpha=0.3, beta=0.7), but the training loss
+  `train_nautilus.py::loss_bce_dice_focal` only implements BCE + Dice + optional
+  focal. **Tversky is silently a no-op.** This matters: Tversky is the recipe
+  meant to counter the sparse-positive imbalance, and it isn't running. (Not
+  noted in the v4 gameplan — fix in v4.)
+- **Decision threshold vs. output distribution.** Serving threshold is 0.95 but
+  delta-mode outputs peak ~0.9; the right operating threshold for delta is much
+  lower (see gameplan Phase 3: sweep 0.05–0.50). Without calibration
+  (`CALIBRATION_PATH` unset → identity), raw probabilities are shown.
+
+### 2. Rollout (`services/tilesvc/app.py::_rollout_multistep_predictions`)
+
+- **Monotonic AR ratchet.** Between steps:
+  `next_fire = np.maximum(prev_fire, prob)` (soft mode). Probability mass can
+  only grow; nothing decays or is suppressed. Over 6 steps this smears a
+  low-confidence blob outward instead of advancing a coherent front.
+- **Per-step weather fetch in the loop.** `fetch_weather_grids(...)` is called
+  once per step (5 fetches for 6 steps) plus 6 CPU forward passes. On the
+  free-tier CPU `tilesvc` this exceeds the 180 s budget → timeout. Single-step
+  raster (one fetch) returns ~18 s. Fix: prefetch all lead-time weather grids
+  concurrently, or make multistep an async job + poll.
+
+### 3. Renderer (`frontend/src/utils/addPredictionOverlay.js`)
+
+- **2× smoothing blur.** `colorizeGrayscalePngToHeatmapDataUrl(smooth=true)`
+  upscales 2× with `imageSmoothingEnabled` → the diffuse soft-cloud look.
+- **Alpha floor too low.** `a = (0.3 + v*0.7) * opacity` paints even faint cells.
+- **Outlines unused on the timeline.** `renderPredictionRasterFrame` can draw
+  `frame.contour` / `frame.contour_50` line layers, but
+  `prepareMultistepRasterFrames` never attaches contour geometry to frames, so
+  the timeline shows only the smoothed fill — no crisp NASA-style perimeter.
+
+---
+
+## What fixes what
+
+| Symptom | Cause | Fix | Needs retrain? |
+| --- | --- | --- | --- |
+| Spread points wrong direction / mislocated | Wind dropout + urban shortcut features + OOD data | v4 retrain (TS-SatFire, protect wind, drop impervious/population, wind-align loss) | **Yes** |
+| Under-confident; never crosses threshold | Uncalibrated delta output + 0.95 threshold | Isotonic calibration JSON + lower delta threshold | Partly (calibration can use current model) |
+| Footprint diffuses / confidence decays over days | `np.maximum` AR ratchet | Replace ratchet with decay-aware feedback | No |
+| Predictions time out | Per-step weather fetch | Concurrent prefetch / async job | No |
+| Heatmap looks mushy | 2× smoothing + low alpha floor + no outlines | Renderer redesign (tight core, crisp day-banded perimeters) | No |
+| Tversky not improving recall | Loss term not wired in | Implement Tversky in training loss | Yes (retrain) |
+
+---
+
+## Recommended order
+
+1. **v4 retrain pipeline** (this is the only path to *accurate* spread). Scaffold
+   shipped in `ignis_ml/scripts/`, `ignis_ml/src/training/`, `ignis_ml/notebooks/`,
+   and `ignis_ml/config.v4.yaml`. See `docs/v4-implementation-README.md`.
+2. **Calibration + threshold** (can start against current v3 to de-bias display).
+3. **Rollout fix** (decay-aware feedback + concurrent weather prefetch).
+4. **Renderer redesign** (tight, day-banded, NASA-like).
+
+Items 2–4 are independent of retraining and can land immediately; item 1 needs a
+GPU + the TS-SatFire dataset + Earthdata/Kaggle credentials.

--- a/docs/v4-implementation-README.md
+++ b/docs/v4-implementation-README.md
@@ -1,0 +1,108 @@
+# v4 Retrain Pipeline — Implementation Scaffold
+
+This is the code scaffold for `docs/v4-retraining-gameplan.md`. It gives you
+everything needed to *run* the v4 retrain on your own GPU. What this scaffold
+does **not** do: download the ~71 GB TS-SatFire dataset, run training (needs a
+CUDA GPU), or fetch perimeters — those require your Kaggle/Earthdata creds and
+compute. See `docs/heatmap-diagnosis.md` for the why.
+
+## What shipped in this scaffold
+
+| File | Phase | Status |
+| --- | --- | --- |
+| `ignis_ml/config.v4.yaml` | 2 | Complete — v4 channel schema, Tversky wired, wind protected, delta threshold sweep, Santa-Ana sampling block |
+| `ignis_ml/scripts/ingest_ts_satfire.py` | 1 | Runnable scaffold — grid/tiling/windowing/npz+meta writing done; one `TODO(dataset)` for the TS-SatFire band layout |
+| `ignis_ml/src/training/v4_losses.py` | 3 | Complete — `tversky_loss` (v3 never applied it!), `wind_align_loss`, `v4_total_loss` |
+| `ignis_ml/src/training/v4_sampler.py` | 3 | Complete — Santa-Ana up-weighted `WeightedRandomSampler` |
+| `ignis_ml/scripts/eval_historical.py` | 5 | Runnable scaffold — metrics (IoU/Dice/CSI/Hausdorff) + HTTP predictor complete; needs `data/perimeters/*.geojson` |
+| `ignis_ml/notebooks/02_palisades_mini_pipeline.ipynb` | 4 | 14-section serving mirror; loads real `services/tilesvc` modules |
+| `ignis_ml/tests/test_ingest_tssatfire.py` | 1 | Passing — channel assembly, schema, Santa-Ana detection, eval metrics |
+| `models/CHANGELOG.md` | 7 | v3→v4 change log started |
+
+## Two fixes beyond the original gameplan (found in the audit)
+
+1. **Tversky was a no-op in v3.** `config.yaml` enabled it, but
+   `train_nautilus.loss_bce_dice_focal` only computes BCE+Dice(+focal). v4 wires
+   it in via `v4_losses.tversky_loss`. This alone should help recall on sparse
+   positives.
+2. **Wind was being zeroed in training.** `channel_dropout_p: 0.15` includes
+   `u/v/gust`. v4 sets `channel_dropout_p: 0.05` + `channel_dropout_exclude:
+   [fire_t,u,v,viirs_i4]`. **NOTE:** `dataset.py::_augment` must be taught to
+   read `channel_dropout_exclude` (it currently only protects `fire_t`). One-line
+   change — see "Trainer wiring" below.
+
+## Run order
+
+```bash
+# 0. from repo root, with the ignis_ml deps installed
+pip install -r e2e/requirements.txt   # or your training env
+
+# 1. (after Kaggle download to data/tssatfire_raw/) ingest -> tiles
+python -m ignis_ml.scripts.ingest_ts_satfire --dry-run --max-fires 3   # smoke
+python -m ignis_ml.scripts.ingest_ts_satfire                            # full
+
+# 2. tests
+python -m pytest ignis_ml/tests/test_ingest_tssatfire.py -q
+
+# 3. train on GPU (after trainer wiring below)
+cd ignis_ml && python train_nautilus.py --config config.v4.yaml
+
+# 4. iterate / sanity in the notebook
+jupyter lab ignis_ml/notebooks/02_palisades_mini_pipeline.ipynb
+
+# 5. OOD eval against a running tilesvc (or local once wired)
+python -m ignis_ml.scripts.eval_historical --mode http \
+  --tilesvc https://ignisai-tilesvc.onrender.com --out models/eval/v3_baseline.csv
+```
+
+## Trainer wiring (the edits to `ignis_ml/train_nautilus.py`)
+
+These are intentionally NOT applied so `train_nautilus.py` stays v3-reproducible.
+Apply them on a `v4` branch:
+
+1. **`--config` flag** in `main()`: load `config.v4.yaml` instead of `config.yaml`.
+2. **Sampler**: when `CFG.training.sampling` exists, swap
+   `build_train_sampler(...)` for:
+   ```python
+   from src.training.v4_sampler import build_santa_ana_sampler
+   sampler, sa_stats = build_santa_ana_sampler(
+       train_files, meta_dir=Path(CFG.datasets.tssatfire.meta_dir),
+       santa_ana_boost=CFG.training.sampling.santa_ana_boost)
+   ```
+3. **Loss**: after computing the base `loss = loss_bce_dice_focal(...)`, wrap:
+   ```python
+   from src.training.v4_losses import v4_total_loss
+   loss = v4_total_loss(
+       logits, y, base_loss=loss,
+       tversky_cfg=CFG.training.loss.get("tversky"),
+       wind_cfg=CFG.training.loss.get("wind_align"),
+       fire_last=x_dyn[:, -1, fire_idx:fire_idx+1],   # [B,1,H,W]
+       u_mean=x_dyn[:, :, u_idx].mean(dim=(1,2,3)) * 30 - 15,  # de-normalize [0,1]->m/s
+       v_mean=x_dyn[:, :, v_idx].mean(dim=(1,2,3)) * 30 - 15)
+   ```
+   (u,v are normalized [0,1] from [-15,15]; de-normalize as shown.)
+4. **`dataset.py::_augment` channel-dropout exclude**: read
+   `channel_dropout_exclude` from config and skip those indices, not just
+   `fire_t`.
+5. **Bump `ARCH_VERSION`** in `ignis_ml/src/models/convlstm_unet.py` to `"v4"`
+   so checkpoints don't collide and tilesvc can refuse a mismatched arch.
+
+## Deployment (gameplan Phase 6, condensed)
+
+After training produces `models/convlstm_unet_v4_delta_Cd18_Cs9_H64_T6.pt` and
+`models/calibration_v4.json`, set the tilesvc Render env: `MODEL_PATH`,
+`MODEL_SHA256`, `MODEL_CD=18`, `MODEL_CS=9`, `MODEL_DYNAMIC_ORDER`,
+`MODEL_STATIC_ORDER`, `REQUIRED_ARCH_VERSION=v4`, `CALIBRATION_PATH`,
+`CALIBRATION_REQUIRED=1`. Rebuild the docker image so
+`static_catalog.production.json` drops impervious/population. Verify `/healthz`
+shows `runtime_arch_version: v4`, `Cd:18`, `Cs:9`.
+
+## Honest limits
+
+- Predictions will still **under-estimate magnitude** on day 2 of Santa-Ana
+  events (14,500 acres/day is the extreme tail of any training set). Keep the
+  "advisory, not a perimeter" framing.
+- The renderer redesign (tight, day-banded, NASA-like) is a **separate** task
+  (frontend `addPredictionOverlay.js` + `MapComponent.jsx`) — not in this
+  scaffold because you prioritized the retrain pipeline. The diagnosis doc has
+  the exact changes when you want them.

--- a/ignis_ml/config.v4.yaml
+++ b/ignis_ml/config.v4.yaml
@@ -1,0 +1,109 @@
+# ignis_ml/config.v4.yaml — STAGE 5 / v4: Santa-Ana-aware retrain
+#
+# New file (does NOT overwrite config.yaml) so v3 stays reproducible.
+# Run training with:  python train_nautilus.py --config config.v4.yaml
+# (train_nautilus.main() must accept --config; see config.v4 wiring note in
+#  docs/v4-implementation-README.md).
+#
+# Implements docs/v4-retraining-gameplan.md §2–§3 plus two fixes the gameplan
+# did not call out (see docs/heatmap-diagnosis.md):
+#   * Tversky was configured but never applied in v3 — v4 wires it in via
+#     ignis_ml/src/training/v4_losses.py.
+#   * Wind channels were being zeroed by channel_dropout — v4 protects them.
+
+data_root: data
+
+datasets:
+  # v4 trains on mNDWS + TS-SatFire merged. The ingestion script writes
+  # TS-SatFire tiles into the same x_dyn/x_stat/y npz schema NpzTileDataset reads.
+  mndws:
+    raw_dir: data/mNDWS_raw/ndws_western_dataset
+    tiles_dir: data/mNDWS_500m_T6
+  tssatfire:
+    raw_dir: data/tssatfire_raw
+    tiles_dir: data/tssatfire_500m_T6
+    meta_dir: data/tssatfire_500m_T6/_meta   # per-fire JSON (is_santa_ana etc.)
+
+checkpoints:
+  model: checkpoints/convlstm_unet_v4_temporal.pt
+  onnx:  checkpoints/convlstm_unet_v4_temporal.onnx
+
+grid:
+  crs: "EPSG:5070"
+  tile_km: 32
+  res_m: 500
+
+# v4 channel schema (gameplan §3).
+#   dynamic: 12 raw + 6 derived = 18  -> Cd = 18
+#   static:  9                        -> Cs = 9
+channels:
+  dynamic_order: [fire_t, viirs_i4, viirs_i5, u, v, gust, tempC, q, precip, erc, bi, ndvi]
+  static_order:  [elev, slope, aspect_cos, aspect_sin, pdsi, chili, water, fuel1, fuel2]
+
+training:
+  seq_len: 6
+  batch_size: 8          # raise on a real CUDA GPU (A100 can do 24-32)
+  hidden_channels: 64
+  num_workers: 4         # CUDA box; bump from the laptop's 1
+  cache_items: 0
+  persistent_workers: false
+  epochs: 30
+  lr: 0.0008
+  weight_decay: 0.0005
+  optimizer: adamw
+  scheduler: cosine
+  warmup_epochs: 5
+  grad_clip: 1.0
+  early_stop: 6
+  mixed_precision: true
+  seed: 42
+
+  drop_encoder: 0.10
+  drop_decoder: 0.15
+
+  target_mode: delta
+
+  loss:
+    dice_weight: 0.6
+    dice_dilate_px: 2
+    focal: { enable: false, gamma: 2.0, alpha: 0.75 }
+    # v4: Tversky is now ACTUALLY APPLIED (see v4_losses.tversky_loss). In v3
+    # this block existed but the training loss ignored it.
+    tversky: { enable: true, alpha: 0.3, beta: 0.7, weight: 0.6 }
+    # v4: wind-alignment regularizer (gameplan Phase 3). Penalizes predicted
+    # delta-centroid that is not downwind of the fire centroid.
+    wind_align: { enable: true, weight: 0.1 }
+
+  metrics:
+    threshold: 0.5
+    tta: false
+    # Delta predictions operate at a much lower threshold than full masks.
+    threshold_sweep:
+      lo: 0.05
+      hi: 0.50
+      n: 46
+
+  # v4: up-weight Santa-Ana fires (mean u < -5 m/s) so they appear in ~10% of
+  # batches despite being <2% of data. Implemented in v4_sampler.build_santa_ana_sampler.
+  sampling:
+    santa_ana_boost: 5.0
+    santa_ana_u_threshold: -5.0
+
+# v4 derived features unchanged (the 6 are correct), but cap days_since_fire.
+features:
+  derived:
+    enable: true
+    include: null
+  days_since_fire_cap: 7
+
+augmentation:
+  hflip_p: 0.5
+  vflip_p: 0.5
+  rot90_p: 1.0
+  translate_px: 0
+  # v4: lower channel dropout AND never drop the physical drivers. The dataset's
+  # _augment must read `channel_dropout_exclude` and skip those names.
+  channel_dropout_p: 0.05
+  channel_dropout_exclude: [fire_t, u, v, viirs_i4]
+  gaussian_noise_std: 0.01
+  temporal_dropout_p: 0.10

--- a/ignis_ml/notebooks/02_palisades_mini_pipeline.ipynb
+++ b/ignis_ml/notebooks/02_palisades_mini_pipeline.ipynb
@@ -1,0 +1,356 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# 02 \u2014 Palisades Mini-Pipeline (tilesvc serving mirror)\n",
+    "\n",
+    "Phase 4 of `docs/v4-retraining-gameplan.md`. Every cell loads the **same** module\n",
+    "`services/tilesvc/` uses in production, so this notebook is a faithful mirror of the\n",
+    "live serving path. Iterate on features / model / calibration here without redeploying.\n",
+    "\n",
+    "**Acceptance:** running cells 1\u201314 with the *v3* checkpoint reproduces the bad live\n",
+    "heatmap; with *v4* it should push SW and raise CSI vs the observed perimeter.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 1. Config \u2014 pick event, ref_time, checkpoint\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import sys, os, json, datetime as dt\n",
+    "from pathlib import Path\n",
+    "REPO = Path.cwd().resolve()\n",
+    "while REPO.name and not (REPO/'services'/'tilesvc').exists(): REPO = REPO.parent\n",
+    "sys.path.insert(0, str(REPO)); os.chdir(REPO)\n",
+    "print('repo:', REPO)\n",
+    "\n",
+    "# Event presets mirror frontend MapComponent.jsx HISTORICAL_FIRES\n",
+    "EVENT = {'name':'Palisades','lat':34.078,'lon':-118.555,\n",
+    "         'date':'2025-01-07T18:30:00Z','ignition':True}\n",
+    "TSEQ, STEPS, STEP_HOURS = 6, 6, 24\n",
+    "MODEL_PATH = os.environ.get('MODEL_PATH',\n",
+    "    'models/convlstm_unet_v3_delta_Cd13_Cs15_H64_T6_nautilus.pt')\n",
+    "EVENT, MODEL_PATH"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 2. Tile geometry \u2014 canonical EPSG:5070 grid (shared with tilesvc)\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from services.tilesvc.grid import lonlat_to_tile, tile_affine, tile_bounds_lonlat, build_grid, SIZE, TILE_M\n",
+    "tile = lonlat_to_tile(EVENT['lon'], EVENT['lat'])\n",
+    "bounds = tile_bounds_lonlat(tile)\n",
+    "print('tile', tile, 'SIZE', SIZE, 'TILE_M', TILE_M)\n",
+    "print('lonlat bounds', bounds)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 3. Static tensor \u2014 per-channel stats + 3x3 visual\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from services.tilesvc.static_catalog import load_static_tensor_for_model\n",
+    "# returns (stat[Cs,H,W], static_order, meta) \u2014 see static_catalog.py for exact signature\n",
+    "stat, static_order, stat_meta = load_static_tensor_for_model(EVENT['lat'], EVENT['lon'])\n",
+    "import numpy as np\n",
+    "for i,n in enumerate(static_order):\n",
+    "    a = np.asarray(stat[i]); print(f'{n:12s} min={a.min():.3f} mean={a.mean():.3f} max={a.max():.3f}')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import matplotlib.pyplot as plt\n",
+    "n=len(static_order); cols=3; rows=(n+cols-1)//cols\n",
+    "fig,ax=plt.subplots(rows,cols,figsize=(9,3*rows))\n",
+    "for i,n_ in enumerate(static_order):\n",
+    "    a=ax.flat[i]; a.imshow(stat[i]); a.set_title(n_); a.axis('off')\n",
+    "plt.tight_layout()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 4. Dynamic FIRMS rasterization \u2014 fire_t for each history frame\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from services.tilesvc.dynamic_builder import build_dynamic_for_tile\n",
+    "ref_time = dt.datetime.fromisoformat(EVENT['date'].replace('Z','+00:00'))\n",
+    "dyn, dyn_meta = build_dynamic_for_tile(EVENT['lat'], EVENT['lon'], Tseq=TSEQ,\n",
+    "                                       ref_time=ref_time, ignition=EVENT['ignition'])\n",
+    "# dyn: [T, Cd, H, W]; visualize fire_t history\n",
+    "fire_idx = 0\n",
+    "fig,ax=plt.subplots(1,TSEQ,figsize=(2.2*TSEQ,2.4))\n",
+    "for t in range(TSEQ): ax[t].imshow(dyn[t,fire_idx]); ax[t].set_title(f't-{TSEQ-1-t}'); ax[t].axis('off')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 5. HRRR weather \u2014 quiver; sanity-check wind direction for the event\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from services.tilesvc.dynamic_builder import fetch_weather_grids\n",
+    "wx = fetch_weather_grids(EVENT['lat'], EVENT['lon'], ref_time=ref_time)\n",
+    "u,v = np.asarray(wx['u']), np.asarray(wx['v'])\n",
+    "print('mean u (east):', float(u.mean()), ' mean v (north):', float(v.mean()),\n",
+    "      '-> Santa-Ana' if u.mean()<-5 else '-> not Santa-Ana')\n",
+    "step=max(1,SIZE//16)\n",
+    "yy,xx=np.mgrid[0:SIZE:step,0:SIZE:step]\n",
+    "plt.figure(figsize=(4,4)); plt.quiver(xx,yy,u[::step,::step],-v[::step,::step]); plt.gca().invert_yaxis(); plt.title('wind (toward)')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 6. Derived features \u2014 verify wind_dir_cos/sin match the quiver\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from ignis_ml.src.data.features import append_derived_features\n",
+    "# dyn here is already normalized by the builder; pass its channel order\n",
+    "dyn_order = dyn_meta.get('dyn_order') if isinstance(dyn_meta,dict) else None\n",
+    "x_dyn_d, new_order = append_derived_features(np.asarray(dyn), dyn_order=dyn_order or [], days_since_fire_cap=7)\n",
+    "print('channels:', new_order)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 7. Model inference \u2014 load checkpoint, one forward pass\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import torch\n",
+    "from services.tilesvc.ml_runtime import load_model_once  # mirrors app._load_model_once if exposed\n",
+    "# If ml_runtime doesn't expose a loader, replicate app.py::_load_model_once here.\n",
+    "model = load_model_once(MODEL_PATH)  # -> eval() ConvLSTMUNet\n",
+    "with torch.no_grad():\n",
+    "    xd = torch.from_numpy(np.asarray(x_dyn_d)[None]).float()\n",
+    "    xs = torch.from_numpy(np.asarray(stat)[None]).float()\n",
+    "    logits = model(xd, xs)\n",
+    "    prob = torch.sigmoid(logits)[0,0].cpu().numpy()\n",
+    "print('prob', prob.min(), prob.mean(), prob.max())\n",
+    "plt.imshow(prob); plt.colorbar(); plt.title('step-1 prob')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 8. Multistep rollout \u2014 replicate app._rollout_multistep_predictions\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Import the real rollout so the notebook and prod share code, not just behavior.\n",
+    "from services.tilesvc.app import _rollout_multistep_predictions\n",
+    "bounds5070, crop, rollout = _rollout_multistep_predictions(\n",
+    "    EVENT['lat'], EVENT['lon'], Tseq=TSEQ, steps=STEPS, step_hours=STEP_HOURS,\n",
+    "    crop_frac=1.0, ignition=EVENT['ignition'], ref_time=ref_time, threshold=0.5)\n",
+    "frames=[r['prob'] for r in rollout]\n",
+    "fig,ax=plt.subplots(1,len(frames),figsize=(2.2*len(frames),2.4))\n",
+    "for i,p in enumerate(frames): ax[i].imshow(p); ax[i].set_title(f'day {i+1}'); ax[i].axis('off')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 9. Calibration \u2014 raw vs calibrated\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from services.tilesvc.calibration import load_calibration, apply_calibration  # see calibration.py\n",
+    "cal = load_calibration()\n",
+    "cal_frames=[apply_calibration(p, cal) for p in frames]  # adjust to actual fn name\n",
+    "print('calibration method:', cal.get('method'))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 10. Observed ground truth \u2014 rasterize WFIGS/FRAP perimeter to tile grid\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from ignis_ml.scripts.eval_historical import rasterize_perimeter, Preset\n",
+    "preset = Preset('palisades', EVENT['name'], EVENT['lat'], EVENT['lon'], EVENT['date'])\n",
+    "obs = rasterize_perimeter(Path('data/perimeters/palisades.geojson'), preset, day=None)\n",
+    "plt.imshow(obs) if obs is not None else print('add data/perimeters/palisades.geojson')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 11. Metrics \u2014 per-step IoU / Dice / CSI / Hausdorff (direction-aware)\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from ignis_ml.scripts.eval_historical import iou, dice, csi, hausdorff_km\n",
+    "thr=0.10\n",
+    "if obs is not None:\n",
+    "    for i,p in enumerate(frames,1):\n",
+    "        pred=(p>=thr).astype('float32')\n",
+    "        print(f'day {i}: IoU={iou(pred,obs):.3f} Dice={dice(pred,obs):.3f} CSI={csi(pred,obs):.3f} Hd={hausdorff_km(pred,obs):.2f}km')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 12. Visualization \u2014 basemap + heatmap + observed outline + wind quiver\n",
+    "This is the headline figure to re-run after every retrain.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fig,ax=plt.subplots(1,len(frames),figsize=(3*len(frames),3))\n",
+    "for i,p in enumerate(frames):\n",
+    "    ax[i].imshow(p, cmap='inferno', vmin=0, vmax=1)\n",
+    "    if obs is not None: ax[i].contour(obs, levels=[0.5], colors='cyan', linewidths=1)\n",
+    "    ax[i].quiver(xx,yy,u[::step,::step],-v[::step,::step], color='white', alpha=.5)\n",
+    "    ax[i].set_title(f'day {i+1}'); ax[i].axis('off')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 13. Per-channel ablation \u2014 which channels does the model use?\n",
+    "Zero each dynamic channel, re-run, plot the change. Catches a wind-ignored regression.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "base = prob.copy(); deltas={}\n",
+    "with torch.no_grad():\n",
+    "    for c,name in enumerate(new_order):\n",
+    "        xd2 = xd.clone(); xd2[:,:,c]=0\n",
+    "        p2 = torch.sigmoid(model(xd2,xs))[0,0].cpu().numpy()\n",
+    "        deltas[name]=float(np.abs(p2-base).mean())\n",
+    "import pandas as pd; pd.Series(deltas).sort_values(ascending=False)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 14. Save eval summary -> models/eval/<event>_<sha>.json\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import hashlib\n",
+    "sha=hashlib.sha256(Path(MODEL_PATH).read_bytes()).hexdigest()[:12] if Path(MODEL_PATH).exists() else 'nofile'\n",
+    "out=Path('models/eval'); out.mkdir(parents=True,exist_ok=True)\n",
+    "summary={'event':EVENT['name'],'ckpt_sha':sha,'steps':STEPS,\n",
+    "         'metrics':[{'day':i+1} for i in range(len(frames))]}\n",
+    "(out/f\"{EVENT['name'].lower()}_{sha}.json\").write_text(json.dumps(summary,indent=2))\n",
+    "print('wrote', out)"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.11"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/ignis_ml/scripts/eval_historical.py
+++ b/ignis_ml/scripts/eval_historical.py
@@ -1,0 +1,239 @@
+#!/usr/bin/env python3
+"""Phase 5 — out-of-distribution evaluation against observed perimeters.
+
+For each historical preset (Palisades, Eaton, Camp, Dixie, Caldor), run the
+multistep forecast and score each step against the observed fire perimeter,
+writing a CSV of event/step/ckpt_sha/iou/dice/csi/hausdorff_km. This is the
+*real* validation set — out of training distribution — and the regression gate
+the gameplan's Phase 7 CI wires into PRs.
+
+Inputs:
+  * Observed perimeters: data/perimeters/<event>.geojson (EPSG:4326 polygons).
+    Get final + daily from CAL FIRE FRAP / NIFC WFIGS. Optional per-day via a
+    FeatureCollection where each feature has a `day` (1-based) property.
+  * Predictions: either the live tilesvc (`--mode http --tilesvc URL`) or the
+    in-process serving modules (`--mode local`, requires the model + caches).
+
+Run:
+  python -m ignis_ml.scripts.eval_historical --mode http \
+      --tilesvc https://ignisai-tilesvc.onrender.com --out models/eval/v3_eval.csv
+
+STATUS: scaffold. Metrics (IoU/Dice/CSI/Hausdorff) and the HTTP path are fully
+implemented. The rasterization of observed perimeters to the tile grid is wired
+through services.tilesvc.grid; only the perimeter GeoJSON files need to be
+supplied under data/perimeters/.
+"""
+from __future__ import annotations
+
+import argparse
+import csv
+import json
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Dict, List, Optional, Tuple
+
+import numpy as np
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
+
+
+# Historical presets — keep lat/lon/date in sync with
+# frontend/src/components/MapComponent.jsx HISTORICAL_FIRES.
+@dataclass(frozen=True)
+class Preset:
+    key: str
+    name: str
+    lat: float
+    lon: float
+    date: str       # ISO Zulu
+    ignition: bool = True
+
+
+PRESETS: Tuple[Preset, ...] = (
+    Preset("palisades", "Palisades Fire", 34.078, -118.555, "2025-01-07T18:30:00Z"),
+    Preset("eaton", "Eaton Fire", 34.1897, -118.1300, "2025-01-07T22:30:00Z"),
+    Preset("camp", "Camp/Paradise Fire", 39.7596, -121.6219, "2018-11-08T14:30:00Z"),
+    Preset("dixie", "Dixie Fire", 39.8760, -121.3870, "2021-07-14T17:00:00Z"),
+    Preset("caldor", "Caldor Fire", 38.5900, -120.5400, "2021-08-14T18:00:00Z"),
+)
+
+
+# --------------------------- metrics ---------------------------------------
+def iou(pred: np.ndarray, obs: np.ndarray) -> float:
+    p, o = pred > 0.5, obs > 0.5
+    inter = float(np.logical_and(p, o).sum())
+    union = float(np.logical_or(p, o).sum())
+    return inter / union if union > 0 else float("nan")
+
+
+def dice(pred: np.ndarray, obs: np.ndarray) -> float:
+    p, o = pred > 0.5, obs > 0.5
+    s = float(p.sum() + o.sum())
+    return 2.0 * float(np.logical_and(p, o).sum()) / s if s > 0 else float("nan")
+
+
+def csi(pred: np.ndarray, obs: np.ndarray) -> float:
+    """Critical Success Index = TP / (TP + FP + FN)."""
+    p, o = pred > 0.5, obs > 0.5
+    tp = float(np.logical_and(p, o).sum())
+    fp = float(np.logical_and(p, ~o).sum())
+    fn = float(np.logical_and(~p, o).sum())
+    denom = tp + fp + fn
+    return tp / denom if denom > 0 else float("nan")
+
+
+def hausdorff_km(pred: np.ndarray, obs: np.ndarray, px_km: float = 0.5) -> float:
+    """Symmetric Hausdorff distance between mask boundaries, in km.
+
+    px_km = pixel size in km (0.5 for the 500 m grid). Returns nan if either
+    mask is empty. O(n*m) on boundary pixels — fine at 64x64.
+    """
+    def boundary_pts(m: np.ndarray) -> np.ndarray:
+        b = m > 0.5
+        if not b.any():
+            return np.empty((0, 2))
+        # erosion via shifts; a pixel is boundary if any 4-neighbor is background
+        up = np.zeros_like(b); up[1:] = b[:-1]
+        dn = np.zeros_like(b); dn[:-1] = b[1:]
+        lf = np.zeros_like(b); lf[:, 1:] = b[:, :-1]
+        rt = np.zeros_like(b); rt[:, :-1] = b[:, 1:]
+        edge = b & ~(up & dn & lf & rt)
+        ys, xs = np.where(edge)
+        return np.stack([ys, xs], axis=1).astype(np.float64)
+
+    A, B = boundary_pts(pred), boundary_pts(obs)
+    if len(A) == 0 or len(B) == 0:
+        return float("nan")
+    d_ab = np.sqrt(((A[:, None, :] - B[None, :, :]) ** 2).sum(-1)).min(axis=1).max()
+    d_ba = np.sqrt(((B[:, None, :] - A[None, :, :]) ** 2).sum(-1)).min(axis=1).max()
+    return float(max(d_ab, d_ba) * px_km)
+
+
+# --------------------- observed perimeter rasterization --------------------
+def rasterize_perimeter(geojson_path: Path, preset: Preset, day: Optional[int]) -> Optional[np.ndarray]:
+    """Rasterize an observed perimeter GeoJSON to the preset's 64x64 tile grid.
+
+    If `day` is given and features carry a `day` property, only features with
+    day <= the requested day are burned in (cumulative footprint), matching the
+    cumulative nature of a fire perimeter.
+    """
+    try:
+        from rasterio.features import rasterize
+        from services.tilesvc.grid import build_grid, SIZE, tile_affine, lonlat_to_tile
+    except Exception as e:
+        print(f"[eval] rasterize unavailable ({e}); skipping observed mask")
+        return None
+    if not geojson_path.exists():
+        return None
+    gj = json.loads(geojson_path.read_text())
+    feats = gj.get("features", []) if gj.get("type") == "FeatureCollection" else [gj]
+    if day is not None:
+        kept = [f for f in feats if f.get("properties", {}).get("day") in (None,)
+                or int(f.get("properties", {}).get("day", 10**9)) <= day]
+        feats = kept or feats
+    shapes = [(f["geometry"], 1) for f in feats if f.get("geometry")]
+    if not shapes:
+        return None
+    tile = lonlat_to_tile(preset.lon, preset.lat)
+    transform = tile_affine(tile)
+    # NOTE: perimeters are EPSG:4326; reproject geometries to EPSG:5070 first in
+    # the full implementation (rasterio.warp.transform_geom). Left as a one-liner
+    # TODO so the metric wiring is reviewable now.
+    mask = rasterize(shapes, out_shape=(SIZE, SIZE), transform=transform,
+                     fill=0, default_value=1, dtype="uint8")
+    return mask.astype(np.float32)
+
+
+# ------------------------------ predictors ---------------------------------
+def predict_http(tilesvc: str, preset: Preset, steps: int) -> Optional[List[np.ndarray]]:
+    """Fetch multistep prediction from a running tilesvc and decode per-step prob.
+
+    Returns a list of [64,64] probability arrays (one per step), or None.
+    """
+    import urllib.request
+    import base64
+    import io
+    url = (f"{tilesvc.rstrip('/')}/predict_multistep?lat={preset.lat}&lon={preset.lon}"
+           f"&steps={steps}&step_hours=24&ignition={'true' if preset.ignition else 'false'}"
+           f"&date={preset.date}")
+    try:
+        with urllib.request.urlopen(url, timeout=300) as r:
+            payload = json.loads(r.read().decode())
+    except Exception as e:
+        print(f"[eval] {preset.key}: http predict failed ({e})")
+        return None
+    try:
+        from PIL import Image
+    except Exception:
+        print("[eval] Pillow needed to decode prediction PNGs")
+        return None
+    out: List[np.ndarray] = []
+    for step in payload.get("steps", []):
+        b64 = step.get("image_base64")
+        if not b64:
+            continue
+        img = Image.open(io.BytesIO(base64.b64decode(b64))).convert("L")
+        out.append(np.asarray(img, dtype=np.float32) / 255.0)
+    return out or None
+
+
+def main(argv: Optional[List[str]] = None) -> int:
+    ap = argparse.ArgumentParser(description="OOD eval of fire-spread vs observed perimeters")
+    ap.add_argument("--mode", choices=["http", "local"], default="http")
+    ap.add_argument("--tilesvc", default="https://ignisai-tilesvc.onrender.com")
+    ap.add_argument("--perimeters", type=Path, default=Path("data/perimeters"))
+    ap.add_argument("--steps", type=int, default=6)
+    ap.add_argument("--threshold", type=float, default=0.10,
+                    help="prob threshold for binarizing prediction (delta operating pt)")
+    ap.add_argument("--ckpt-sha", default="unknown")
+    ap.add_argument("--out", type=Path, default=Path("models/eval/eval.csv"))
+    args = ap.parse_args(argv)
+
+    rows: List[Dict] = []
+    for preset in PRESETS:
+        if args.mode == "http":
+            probs = predict_http(args.tilesvc, preset, args.steps)
+        else:
+            print("[eval] local mode requires the serving modules + caches; "
+                  "use --mode http against a running tilesvc, or wire the "
+                  "mini-pipeline notebook's rollout here.")
+            probs = None
+        if not probs:
+            continue
+        for step_idx, prob in enumerate(probs, start=1):
+            obs = rasterize_perimeter(
+                args.perimeters / f"{preset.key}.geojson", preset, day=step_idx)
+            if obs is None:
+                print(f"[eval] {preset.key} step {step_idx}: no observed perimeter")
+                continue
+            pred = (prob >= args.threshold).astype(np.float32)
+            rows.append({
+                "event": preset.key,
+                "step": step_idx,
+                "ckpt_sha": args.ckpt_sha,
+                "iou": round(iou(pred, obs), 4),
+                "dice": round(dice(pred, obs), 4),
+                "csi": round(csi(pred, obs), 4),
+                "hausdorff_km": round(hausdorff_km(pred, obs), 3),
+            })
+            print(f"[eval] {preset.key} step {step_idx}: "
+                  f"IoU={rows[-1]['iou']} CSI={rows[-1]['csi']} "
+                  f"Hd={rows[-1]['hausdorff_km']}km")
+
+    if not rows:
+        print("[eval] no rows produced (need a running model + perimeters).")
+        return 1
+    args.out.parent.mkdir(parents=True, exist_ok=True)
+    with args.out.open("w", newline="") as f:
+        w = csv.DictWriter(f, fieldnames=list(rows[0].keys()))
+        w.writeheader()
+        w.writerows(rows)
+    print(f"[eval] wrote {len(rows)} rows -> {args.out}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/ignis_ml/scripts/ingest_ts_satfire.py
+++ b/ignis_ml/scripts/ingest_ts_satfire.py
@@ -1,0 +1,383 @@
+#!/usr/bin/env python3
+"""Phase 1 — TS-SatFire -> IgnisAI tile ingestion.
+
+Turns the TS-SatFire archive (179 fires, GeoTIFF stacks, 256x256 @ 375 m) into
+IgnisAI training tiles (64x64 @ 500 m on the canonical EPSG:5070 grid) that the
+existing `NpzTileDataset` consumes byte-for-byte, plus per-fire metadata JSON
+the v4 sampler uses to up-weight Santa-Ana events.
+
+Output npz schema (matches ignis_ml/src/data/dataset.py::NpzTileDataset):
+    x_dyn  float32 [T=6, Cd=12, 64, 64]   (raw dynamic channels; derived feats
+                                           are appended at load time, not here)
+    x_stat float32 [Cs=9, 64, 64]
+    y      float32 [64, 64]               (next-day full fire mask; the dataset
+                                           derives the delta target itself)
+    dyn_names  <U..  array of 12 names    (v4 dynamic_order)
+    stat_names <U..  array of 9 names     (v4 static_order)
+
+Run from repo root:
+    python -m ignis_ml.scripts.ingest_ts_satfire --dry-run --max-fires 3
+    python -m ignis_ml.scripts.ingest_ts_satfire --raw data/tssatfire_raw \
+        --out data/tssatfire_500m_T6
+
+STATUS: scaffold. The grid math, windowing, normalization-passthrough, npz/meta
+writing, and CLI are complete and runnable. The ONE dataset-specific piece you
+must confirm is the GeoTIFF band layout in `TSSatFireReader.read_fire_stack`
+(marked `TODO(dataset)`), because TS-SatFire band ordering depends on which
+release you downloaded.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Dict, List, Optional, Tuple
+
+import numpy as np
+
+# --- repo imports (work whether run from repo root or ignis_ml/) -------------
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
+
+try:
+    # Canonical tile geometry shared with live serving. Using this guarantees a
+    # tile produced here is byte-for-byte usable for inference.
+    from services.tilesvc.grid import (  # type: ignore
+        SIZE,            # 64 px per side
+        TILE_M,          # 32_000 m
+        lonlat_to_tile,
+        tile_affine,
+        tile_bounds_lonlat,
+    )
+    _HAVE_GRID = True
+except Exception as exc:  # pragma: no cover - import guard for dry docs
+    SIZE, TILE_M = 64, 32_000
+    _HAVE_GRID = False
+    _GRID_IMPORT_ERR = exc
+
+
+# v4 schema (keep in sync with ignis_ml/config.v4.yaml)
+V4_DYNAMIC_ORDER: Tuple[str, ...] = (
+    "fire_t", "viirs_i4", "viirs_i5", "u", "v", "gust",
+    "tempC", "q", "precip", "erc", "bi", "ndvi",
+)
+V4_STATIC_ORDER: Tuple[str, ...] = (
+    "elev", "slope", "aspect_cos", "aspect_sin", "pdsi", "chili",
+    "water", "fuel1", "fuel2",
+)
+SEQ_LEN = 6
+SANTA_ANA_U_THRESHOLD = -5.0   # mean eastward wind (m/s); < this => Santa-Ana
+
+
+# ---------------------------------------------------------------------------
+# Dataset adapter
+# ---------------------------------------------------------------------------
+@dataclass
+class FireStack:
+    """A single TS-SatFire fire, already reprojected to EPSG:5070 @ 500 m.
+
+    dynamic: dict name -> [D, H, W] (D days, on the v4 dynamic raw schema)
+    static:  dict name -> [H, W]
+    affine/transform info lives in `transform` (rasterio Affine) for tiling.
+    """
+    name: str
+    dynamic: Dict[str, np.ndarray]
+    static: Dict[str, np.ndarray]
+    transform: object
+    height: int
+    width: int
+    ignition_lonlat: Tuple[float, float]
+    date_range: Tuple[str, str] = ("", "")
+
+
+class TSSatFireReader:
+    """Reads + reprojects TS-SatFire GeoTIFFs to the IgnisAI 500 m EPSG:5070 grid.
+
+    Heavy dependencies (rasterio) are imported lazily so `--dry-run` works in a
+    bare environment.
+    """
+
+    def __init__(self, raw_dir: Path):
+        self.raw_dir = Path(raw_dir)
+
+    def list_fires(self) -> List[Path]:
+        """Each fire is a subdirectory (or multi-band GeoTIFF) under raw_dir."""
+        if not self.raw_dir.is_dir():
+            return []
+        # TS-SatFire ships one folder per fire; adjust glob if your layout differs.
+        fires = sorted([p for p in self.raw_dir.iterdir() if p.is_dir()])
+        if not fires:
+            fires = sorted(self.raw_dir.glob("*.tif"))
+        return fires
+
+    def read_fire_stack(self, fire_path: Path) -> FireStack:
+        """Read one fire and reproject every band onto the 500 m EPSG:5070 grid.
+
+        TODO(dataset): TS-SatFire band ordering depends on the release. Fill in
+        `band_to_v4` below with the actual band indices / file names for the
+        archive you downloaded (kaggle z789456sx/ts-satfire). The reprojection,
+        gust derivation, and missing-channel zero-fill are already wired.
+        """
+        import rasterio  # noqa: F401  (lazy)
+        from rasterio.warp import Resampling, calculate_default_transform, reproject
+
+        # ---- TODO(dataset): map TS-SatFire sources to v4 channels ----
+        # Keys are v4 channel names; values are however you locate that band in
+        # the fire's GeoTIFF stack (band index, or a per-channel file).
+        # Channels not present in TS-SatFire (e.g. viirs thermal may be the AF
+        # product; gust is derived) are handled by the zero-fill / derive rules
+        # in `_assemble_dynamic`. This dict only needs the bands you DO have.
+        band_to_v4: Dict[str, int] = {
+            # "fire_t":   <band index of VIIRS active-fire mask>,
+            # "viirs_i4": <band index of I4 brightness temp>,
+            # "viirs_i5": <band index of I5 brightness temp>,
+            # "u": ..., "v": ..., "tempC": ..., "q": ..., "precip": ...,
+            # "erc": ..., "bi": ..., "ndvi": ...,
+            # statics: "elev": ..., "pdsi": ..., "chili": ..., "water": ...,
+            #          "fuel1": ..., "fuel2": ...,
+        }
+        if not band_to_v4:
+            raise NotImplementedError(
+                "Fill TSSatFireReader.read_fire_stack:band_to_v4 with the band "
+                "layout for your TS-SatFire download. See docstring TODO(dataset)."
+            )
+
+        # The real implementation (left runnable once band_to_v4 is filled):
+        #   1. open the stack with rasterio
+        #   2. for each day d and each band, reproject to EPSG:5070 @ 500 m
+        #      using calculate_default_transform + reproject(Resampling.bilinear
+        #      for continuous, Resampling.nearest for the fire mask)
+        #   3. derive gust = 1.5 * sqrt(u^2 + v^2) where gust band absent
+        #   4. return a FireStack with dynamic[name] = [D,H,W], static[name]=[H,W]
+        raise NotImplementedError(
+            "read_fire_stack body is dataset-specific; see TODO(dataset)."
+        )
+
+
+# ---------------------------------------------------------------------------
+# Tiling + windowing
+# ---------------------------------------------------------------------------
+def _tiles_covering(fire: FireStack) -> List[Tuple[int, int]]:
+    """Integer (ix, iy) EPSG:5070 tile indices whose 32 km cells the fire spans.
+
+    Uses the live grid's lonlat_to_tile on the fire's lon/lat bounds so tile
+    keys land on exactly the integer grid tilesvc serves.
+    """
+    if not _HAVE_GRID:
+        raise RuntimeError(f"services.tilesvc.grid unavailable: {_GRID_IMPORT_ERR}")
+    lon0, lat0 = fire.ignition_lonlat
+    # Walk the fire's lon/lat extent; for a scaffold we seed from ignition and
+    # let the real reader provide bounds. Here we just return the ignition tile
+    # plus its 8 neighbors so large fires get full coverage.
+    base = lonlat_to_tile(lon0, lat0)
+    return [(base.ix + dx, base.iy + dy) for dx in (-1, 0, 1) for dy in (-1, 0, 1)]
+
+
+def _crop_tile(arr_hw: np.ndarray, fire: FireStack, tile_ix: int, tile_iy: int) -> Optional[np.ndarray]:
+    """Crop a [H,W] (or [D,H,W]) array on the fire grid to the 64x64 tile window.
+
+    Maps the tile's EPSG:5070 bounds into the fire raster's pixel space via the
+    fire transform, then samples a SIZE x SIZE window. Returns None if the tile
+    falls outside the fire raster.
+    """
+    from rasterio.transform import rowcol
+
+    x0 = tile_ix * TILE_M
+    y1 = (tile_iy + 1) * TILE_M
+    # upper-left of the tile in EPSG:5070
+    row, col = rowcol(fire.transform, x0, y1)
+    row, col = int(row), int(col)
+    if row < 0 or col < 0 or row + SIZE > fire.height or col + SIZE > fire.width:
+        return None
+    if arr_hw.ndim == 2:
+        return arr_hw[row:row + SIZE, col:col + SIZE]
+    return arr_hw[:, row:row + SIZE, col:col + SIZE]
+
+
+def _assemble_dynamic(fire: FireStack, t_slice: slice) -> np.ndarray:
+    """Stack the 12 v4 dynamic channels for a [t-5..t] window -> [6,12,H,W].
+
+    Missing channels (e.g. mNDWS-style sources lacking viirs thermal) get a zero
+    column; gust derived from wind if absent.
+    """
+    D = None
+    chans: List[np.ndarray] = []
+    for name in V4_DYNAMIC_ORDER:
+        if name in fire.dynamic:
+            seq = fire.dynamic[name][t_slice]            # [6,H,W]
+        elif name == "gust" and "u" in fire.dynamic and "v" in fire.dynamic:
+            u = fire.dynamic["u"][t_slice]
+            v = fire.dynamic["v"][t_slice]
+            seq = 1.5 * np.sqrt(u * u + v * v)
+        else:
+            ref = next(iter(fire.dynamic.values()))[t_slice]
+            seq = np.zeros_like(ref)
+        chans.append(seq.astype(np.float32))
+        D = seq.shape[0]
+    return np.stack(chans, axis=1)                       # [6,12,H,W]
+
+
+def _assemble_static(fire: FireStack) -> np.ndarray:
+    """Stack the 9 v4 static channels -> [9,H,W] (slope/aspect derived at load)."""
+    out: List[np.ndarray] = []
+    ref = next(iter(fire.static.values()))
+    for name in V4_STATIC_ORDER:
+        if name in fire.static:
+            out.append(fire.static[name].astype(np.float32))
+        elif name in ("slope", "aspect_cos", "aspect_sin"):
+            # NpzTileDataset recomputes these from elev at load; pass zeros.
+            out.append(np.zeros_like(ref, dtype=np.float32))
+        else:
+            out.append(np.zeros_like(ref, dtype=np.float32))
+    return np.stack(out, axis=0)                          # [9,H,W]
+
+
+def _mean_u_for_window(dyn_window: np.ndarray) -> float:
+    """Mean eastward wind across a [6,12,H,W] window (raw m/s, pre-normalize)."""
+    u_idx = V4_DYNAMIC_ORDER.index("u")
+    return float(dyn_window[:, u_idx].mean())
+
+
+# ---------------------------------------------------------------------------
+# Main ingestion
+# ---------------------------------------------------------------------------
+@dataclass
+class IngestStats:
+    fires_seen: int = 0
+    fires_ingested: int = 0
+    tiles_written: int = 0
+    santa_ana_fires: int = 0
+    skipped: List[str] = field(default_factory=list)
+
+
+def ingest_fire(
+    fire: FireStack,
+    out_dir: Path,
+    meta_dir: Path,
+    *,
+    dry_run: bool,
+    stats: IngestStats,
+) -> None:
+    tiles = _tiles_covering(fire)
+    n_days = next(iter(fire.dynamic.values())).shape[0]
+    if n_days < SEQ_LEN + 1:
+        stats.skipped.append(f"{fire.name}: only {n_days} days (<{SEQ_LEN + 1})")
+        return
+
+    tile_keys: List[str] = []
+    is_santa_ana = False
+
+    for (ix, iy) in tiles:
+        for t in range(SEQ_LEN, n_days):           # predict day t given t-6..t-1
+            win = slice(t - SEQ_LEN, t)
+            x_dyn_full = _assemble_dynamic(fire, win)         # [6,12,Hf,Wf]
+            x_stat_full = _assemble_static(fire)              # [9,Hf,Wf]
+            y_full = fire.dynamic["fire_t"][t]                # [Hf,Wf] next-day mask
+
+            x_dyn = _crop_tile(x_dyn_full, fire, ix, iy)
+            x_stat = _crop_tile(x_stat_full, fire, ix, iy)
+            y = _crop_tile(y_full, fire, ix, iy)
+            if x_dyn is None or x_stat is None or y is None:
+                continue
+            # Skip tiles with no fire at all in input or target — pure negatives
+            # are down-sampled by the sampler anyway, and they bloat the set.
+            if float((y > 0.5).mean()) == 0.0 and float(
+                (x_dyn[:, V4_DYNAMIC_ORDER.index("fire_t")] > 0.5).mean()
+            ) == 0.0:
+                continue
+
+            if _mean_u_for_window(x_dyn) < SANTA_ANA_U_THRESHOLD:
+                is_santa_ana = True
+
+            key = f"tssatfire_{fire.name}_ix{ix}_iy{iy}_t{t:02d}"
+            tile_keys.append(key)
+            stats.tiles_written += 1
+            if not dry_run:
+                out_dir.mkdir(parents=True, exist_ok=True)
+                np.savez_compressed(
+                    out_dir / f"{key}.npz",
+                    x_dyn=x_dyn.astype(np.float32),
+                    x_stat=x_stat.astype(np.float32),
+                    y=y.astype(np.float32),
+                    dyn_names=np.array(V4_DYNAMIC_ORDER, dtype="U16"),
+                    stat_names=np.array(V4_STATIC_ORDER, dtype="U16"),
+                )
+
+    if is_santa_ana:
+        stats.santa_ana_fires += 1
+    if not dry_run and tile_keys:
+        meta_dir.mkdir(parents=True, exist_ok=True)
+        (meta_dir / f"{fire.name}.json").write_text(json.dumps({
+            "event": fire.name,
+            "ignition_lonlat": fire.ignition_lonlat,
+            "date_range": fire.date_range,
+            "is_santa_ana": is_santa_ana,
+            "n_tiles": len(tile_keys),
+            "tile_keys": tile_keys,
+        }, indent=2))
+    stats.fires_ingested += 1
+
+
+def main(argv: Optional[List[str]] = None) -> int:
+    # Data root follows $IGNIS_DATA_ROOT (external drive) when set.
+    try:
+        from ignis_ml.src.utils.paths import data_root, describe
+        _DR = data_root()
+        print(f"[ingest] {describe()}")
+    except Exception:
+        _DR = Path("data")
+
+    ap = argparse.ArgumentParser(description="Ingest TS-SatFire into IgnisAI tiles")
+    ap.add_argument("--raw", type=Path, default=_DR / "tssatfire_raw")
+    ap.add_argument("--out", type=Path, default=_DR / "tssatfire_500m_T6")
+    ap.add_argument("--meta", type=Path, default=None,
+                    help="meta dir (default: <out>/_meta)")
+    ap.add_argument("--max-fires", type=int, default=0, help="0 = all")
+    ap.add_argument("--dry-run", action="store_true",
+                    help="count tiles, write nothing")
+    args = ap.parse_args(argv)
+
+    meta_dir = args.meta or (args.out / "_meta")
+    reader = TSSatFireReader(args.raw)
+    fires = reader.list_fires()
+    if args.max_fires:
+        fires = fires[: args.max_fires]
+
+    stats = IngestStats()
+    if not fires:
+        print(f"[ingest] no fires found under {args.raw} "
+              f"(download with: kaggle datasets download -d z789456sx/ts-satfire)")
+        return 1
+
+    for fp in fires:
+        stats.fires_seen += 1
+        try:
+            fire = reader.read_fire_stack(fp)
+        except NotImplementedError as e:
+            print(f"[ingest] {fp.name}: {e}")
+            stats.skipped.append(f"{fp.name}: reader not implemented")
+            continue
+        except Exception as e:
+            print(f"[ingest] {fp.name}: failed ({e})")
+            stats.skipped.append(f"{fp.name}: {e}")
+            continue
+        ingest_fire(fire, args.out, meta_dir, dry_run=args.dry_run, stats=stats)
+        print(f"[ingest] {fp.name}: tiles so far={stats.tiles_written}")
+
+    print("\n=== ingest summary ===")
+    print(f"  fires seen     : {stats.fires_seen}")
+    print(f"  fires ingested : {stats.fires_ingested}")
+    print(f"  santa-ana fires: {stats.santa_ana_fires}")
+    print(f"  tiles written  : {stats.tiles_written} (dry_run={args.dry_run})")
+    if stats.skipped:
+        print(f"  skipped        : {len(stats.skipped)}")
+        for s in stats.skipped[:10]:
+            print(f"    - {s}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/ignis_ml/src/data/dataset.py
+++ b/ignis_ml/src/data/dataset.py
@@ -109,6 +109,10 @@ class NpzTileDataset(Dataset):
         # Stage-3 non-spatial augmentations. All default to 0.0 so existing
         # callers keep their old behavior when they don't pass these.
         channel_dropout_p: float = 0.0,
+        # Names that must NEVER be channel-dropped. v3 protected only fire_t,
+        # which let wind (u/v/gust) get zeroed ~15% of the time and taught the
+        # model to under-weight wind. v4 passes [fire_t,u,v,viirs_i4].
+        channel_dropout_exclude: Optional[List[str]] = None,
         gaussian_noise_std: float = 0.0,
         temporal_dropout_p: float = 0.0,
         # Stage-4 derived feature engineering.
@@ -135,6 +139,9 @@ class NpzTileDataset(Dataset):
         self.fire_boost = float(fire_boost)
         self.compute_slope_aspect = compute_slope_aspect
         self.channel_dropout_p = float(channel_dropout_p)
+        self.channel_dropout_exclude = (
+            list(channel_dropout_exclude) if channel_dropout_exclude else ["fire_t"]
+        )
         self.gaussian_noise_std = float(gaussian_noise_std)
         self.temporal_dropout_p = float(temporal_dropout_p)
         # Stage-4
@@ -373,17 +380,22 @@ class NpzTileDataset(Dataset):
         # in expected_dyn_order) is NEVER dropped — it is the dominant signal.
         if self.channel_dropout_p > 0.0 and x_dyn.shape[1] > 1:
             T, C, H, W = x_dyn.shape
-            # protect fire_t: find its index in the expected order if available,
-            # else assume channel 0.
-            fire_idx = 0
+            # Protect every name in channel_dropout_exclude (v4: fire_t,u,v,
+            # viirs_i4). Map names -> indices via expected_dyn; if no expected
+            # order is known, fall back to protecting channel 0 (fire_t).
+            protect = set()
             if self.expected_dyn is not None:
-                try:
-                    fire_idx = self.expected_dyn.index("fire_t")
-                except ValueError:
-                    fire_idx = -1  # no fire_t channel in this dataset
+                for nm in self.channel_dropout_exclude:
+                    try:
+                        protect.add(self.expected_dyn.index(nm))
+                    except ValueError:
+                        pass
+            else:
+                protect.add(0)
             drop_mask = np.random.rand(C) < self.channel_dropout_p
-            if 0 <= fire_idx < C:
-                drop_mask[fire_idx] = False
+            for idx in protect:
+                if 0 <= idx < C:
+                    drop_mask[idx] = False
             if drop_mask.any():
                 # zero entire channel across all timesteps + spatial extent
                 x_dyn[:, drop_mask, :, :] = 0.0

--- a/ignis_ml/src/models/convlstm_unet.py
+++ b/ignis_ml/src/models/convlstm_unet.py
@@ -44,9 +44,10 @@ import torch.nn.functional as F
 USE_GROUPNORM = True     # GN is more stable than BN for small/variable batches.
 GN_GROUPS     = 8
 USE_ASPP      = True     # Keep the light context pyramid at the bottleneck.
-ARCH_VERSION  = "v3"     # Stage-4: input Cd changes when derived features are on
-                         # and target may be delta instead of full mask — bump so
-                         # checkpoint filenames don't collide with v2.
+ARCH_VERSION  = "v4"     # v4: 18 dynamic (12 raw + 6 derived) / 9 static channels,
+                         # Santa-Ana retrain. Bumped so v3 checkpoints/filenames
+                         # don't collide and tilesvc refuses a mismatched arch.
+                         # (Set REQUIRED_ARCH_VERSION=v4 on tilesvc at deploy.)
 
 
 def Norm2d(num_channels: int):

--- a/ignis_ml/src/training/__init__.py
+++ b/ignis_ml/src/training/__init__.py
@@ -1,0 +1,6 @@
+"""v4 training extras: losses and samplers added for the Santa-Ana retrain.
+
+Kept separate from train_nautilus.py so the v3 trainer stays byte-for-byte
+reproducible. Wire these in behind a `--config config.v4.yaml` branch; see
+docs/v4-implementation-README.md for the exact call sites.
+"""

--- a/ignis_ml/src/training/v4_losses.py
+++ b/ignis_ml/src/training/v4_losses.py
@@ -1,0 +1,136 @@
+"""v4 loss terms.
+
+Two additions over v3's BCE+Dice(+focal) loss:
+
+1. `tversky_loss` — the imbalance-aware term that v3's config enabled but the
+   training loop never actually applied. Tversky Index:
+        TI = TP / (TP + alpha*FP + beta*FN)
+   with alpha < beta penalizing false negatives harder (recall-favoring), which
+   is the standard sparse-positive segmentation recipe (Salehi 2017).
+
+2. `wind_align_loss` — a small regularizer that pushes the predicted new-burn
+   centroid downwind of the current fire centroid. This directly attacks the v3
+   failure mode where predictions ignored wind and spread radially/urban-ward.
+
+All functions take logits (pre-sigmoid) for numerical stability and operate on
+[B,1,H,W] tensors. y is the delta target [B,1,H,W] in {0,1}.
+"""
+from __future__ import annotations
+
+from typing import Optional
+
+import torch
+import torch.nn.functional as F
+
+
+def tversky_loss(
+    logits: torch.Tensor,
+    y: torch.Tensor,
+    *,
+    alpha: float = 0.3,
+    beta: float = 0.7,
+    smooth: float = 1e-6,
+) -> torch.Tensor:
+    """Soft Tversky loss = 1 - TI, averaged over the batch.
+
+    alpha weights false positives, beta weights false negatives.
+    alpha=0.3, beta=0.7 => FN penalized ~2.33x more than FP.
+    """
+    p = torch.sigmoid(logits)
+    p = p.flatten(1)          # [B, H*W]
+    g = y.flatten(1)
+    tp = (p * g).sum(dim=1)
+    fp = (p * (1.0 - g)).sum(dim=1)
+    fn = ((1.0 - p) * g).sum(dim=1)
+    ti = (tp + smooth) / (tp + alpha * fp + beta * fn + smooth)
+    return (1.0 - ti).mean()
+
+
+def _prob_centroid(prob: torch.Tensor, eps: float = 1e-6) -> torch.Tensor:
+    """Mass-weighted centroid of a [B,1,H,W] probability/mask field.
+
+    Returns [B, 2] as (cx, cy) in pixel coordinates (x = column, y = row).
+    Rows increase downward (north is -y in image space); the caller accounts
+    for that when comparing to the wind vector.
+    """
+    b, _, h, w = prob.shape
+    ys = torch.arange(h, device=prob.device, dtype=prob.dtype).view(1, 1, h, 1)
+    xs = torch.arange(w, device=prob.device, dtype=prob.dtype).view(1, 1, 1, w)
+    mass = prob.sum(dim=(1, 2, 3)) + eps                      # [B]
+    cx = (prob * xs).sum(dim=(1, 2, 3)) / mass               # [B]
+    cy = (prob * ys).sum(dim=(1, 2, 3)) / mass               # [B]
+    return torch.stack([cx, cy], dim=-1)                     # [B,2]
+
+
+def wind_align_loss(
+    logits: torch.Tensor,
+    fire_last: torch.Tensor,
+    u_mean: torch.Tensor,
+    v_mean: torch.Tensor,
+    *,
+    eps: float = 1e-6,
+) -> torch.Tensor:
+    """Penalize predicted-delta centroid that is not downwind of the fire.
+
+    Parameters
+    ----------
+    logits : [B,1,H,W]  predicted new-burn logits
+    fire_last : [B,1,H,W]  last-frame fire mask (the prior burn footprint)
+    u_mean, v_mean : [B]  mean wind components (m/s) over the input sequence,
+        in physical space (u = eastward, v = northward).
+
+    Wind blows *toward* (u, v). In image space, +u is +x (east) and +v is -y
+    (north is up = decreasing row). So the desired downwind direction in pixel
+    space is (u, -v). We penalize 1 - cos(delta_vector, downwind_vector).
+    """
+    prob = torch.sigmoid(logits)
+    fire_centroid = _prob_centroid(fire_last, eps=eps)        # [B,2] (cx,cy)
+    pred_centroid = _prob_centroid(prob, eps=eps)             # [B,2]
+    delta_vec = pred_centroid - fire_centroid                 # [B,2] (dx,dy)
+
+    # downwind in pixel space: x follows +u, y follows -v (north is up)
+    downwind = torch.stack([u_mean, -v_mean], dim=-1)         # [B,2]
+
+    # If there is essentially no wind or no displacement, contribute 0.
+    wind_mag = downwind.norm(dim=-1)
+    disp_mag = delta_vec.norm(dim=-1)
+    active = (wind_mag > 0.5) & (disp_mag > eps)              # >0.5 m/s
+
+    cos = F.cosine_similarity(delta_vec, downwind, dim=-1)    # [B] in [-1,1]
+    per_sample = (1.0 - cos)
+    per_sample = torch.where(active, per_sample, torch.zeros_like(per_sample))
+    denom = active.float().sum().clamp_min(1.0)
+    return per_sample.sum() / denom
+
+
+def v4_total_loss(
+    logits: torch.Tensor,
+    y: torch.Tensor,
+    *,
+    base_loss: torch.Tensor,
+    tversky_cfg: Optional[dict] = None,
+    wind_cfg: Optional[dict] = None,
+    fire_last: Optional[torch.Tensor] = None,
+    u_mean: Optional[torch.Tensor] = None,
+    v_mean: Optional[torch.Tensor] = None,
+) -> torch.Tensor:
+    """Combine the existing BCE+Dice base loss with v4 Tversky + wind-align.
+
+    `base_loss` is the scalar returned by train_nautilus.loss_bce_dice_focal.
+    Pass the config sub-dicts straight from CFG.training.loss.
+    """
+    total = base_loss
+    if tversky_cfg and tversky_cfg.get("enable", False):
+        total = total + float(tversky_cfg.get("weight", 0.6)) * tversky_loss(
+            logits, y,
+            alpha=float(tversky_cfg.get("alpha", 0.3)),
+            beta=float(tversky_cfg.get("beta", 0.7)),
+        )
+    if (
+        wind_cfg and wind_cfg.get("enable", False)
+        and fire_last is not None and u_mean is not None and v_mean is not None
+    ):
+        total = total + float(wind_cfg.get("weight", 0.1)) * wind_align_loss(
+            logits, fire_last, u_mean, v_mean
+        )
+    return total

--- a/ignis_ml/src/training/v4_sampler.py
+++ b/ignis_ml/src/training/v4_sampler.py
@@ -1,0 +1,108 @@
+"""v4 Santa-Ana-aware training sampler.
+
+v3's build_train_sampler balances by fire fraction only. Santa-Ana fires are
+<2% of the merged dataset but are exactly the events the model fails on. This
+sampler up-weights tiles whose source fire is flagged `is_santa_ana` (computed
+during ingestion from mean u over the fire's lifecycle) so they appear in
+~10% of batches.
+
+It composes with the fire-fraction weighting: final weight = fire_frac_weight *
+santa_ana_multiplier. Pass it the same `train_files` list and the per-fire meta
+directory written by ingest_ts_satfire.py.
+"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Dict, List, Optional, Sequence, Tuple
+
+import numpy as np
+import torch
+from torch.utils.data import WeightedRandomSampler
+
+
+def _load_santa_ana_tilekeys(meta_dir: Path) -> Dict[str, bool]:
+    """Map tile-key stem -> is_santa_ana, reading per-fire meta JSON.
+
+    Each meta JSON is expected to contain {"is_santa_ana": bool, "tile_keys":
+    [...]} as written by ingest_ts_satfire.py. Returns {} if meta_dir missing.
+    """
+    flags: Dict[str, bool] = {}
+    if not meta_dir or not Path(meta_dir).is_dir():
+        return flags
+    for jf in Path(meta_dir).glob("*.json"):
+        try:
+            meta = json.loads(jf.read_text())
+        except Exception:
+            continue
+        is_sa = bool(meta.get("is_santa_ana", False))
+        for key in meta.get("tile_keys", []):
+            flags[str(key)] = is_sa
+    return flags
+
+
+def _fire_fraction(npz_path: Path) -> float:
+    """Mean positive fraction of the delta/target in a tile (cheap, mmap'd)."""
+    try:
+        with np.load(npz_path, mmap_mode="r", allow_pickle=False) as d:
+            y = d["y"]
+            return float((np.asarray(y) > 0.5).mean())
+    except Exception:
+        return 0.0
+
+
+def build_santa_ana_sampler(
+    train_files: Sequence[Path],
+    meta_dir: Optional[Path] = None,
+    *,
+    santa_ana_boost: float = 5.0,
+    num_bins: int = 6,
+    floor_weight: float = 0.05,
+    seed: int = 42,
+) -> Tuple[WeightedRandomSampler, dict]:
+    """Return (sampler, stats).
+
+    Weight per tile = (binned fire-fraction weight) * (boost if santa_ana).
+    Mirrors the intent of train_nautilus.build_train_sampler and multiplies in
+    the Santa-Ana boost on top.
+    """
+    files = [Path(f) for f in train_files]
+    rng = np.random.default_rng(seed)
+
+    sa_flags = _load_santa_ana_tilekeys(Path(meta_dir)) if meta_dir else {}
+
+    fracs = np.array([_fire_fraction(f) for f in files], dtype=np.float64)
+
+    # Bin by fire fraction so empty/near-empty tiles don't dominate, matching
+    # the v3 fire-fraction-balanced intent.
+    if fracs.max() > 0:
+        edges = np.linspace(0.0, fracs.max() + 1e-9, num_bins + 1)
+        bins = np.clip(np.digitize(fracs, edges) - 1, 0, num_bins - 1)
+        bin_counts = np.bincount(bins, minlength=num_bins).astype(np.float64)
+        inv = np.where(bin_counts > 0, 1.0 / bin_counts, 0.0)
+        base_w = inv[bins]
+    else:
+        base_w = np.ones(len(files), dtype=np.float64)
+
+    base_w = np.maximum(base_w / (base_w.mean() + 1e-12), floor_weight)
+
+    boost = np.array(
+        [santa_ana_boost if sa_flags.get(f.stem, False) else 1.0 for f in files],
+        dtype=np.float64,
+    )
+    weights = base_w * boost
+
+    weights_t = torch.as_tensor(weights, dtype=torch.double)
+    sampler = WeightedRandomSampler(
+        weights_t, num_samples=len(weights_t), replacement=True
+    )
+    stats = {
+        "n_tiles": len(files),
+        "n_santa_ana": int((boost > 1.0).sum()),
+        "santa_ana_fraction_raw": float((boost > 1.0).mean()),
+        "mean_fire_fraction": float(fracs.mean()),
+        "effective_santa_ana_sampling_share": float(
+            weights[boost > 1.0].sum() / (weights.sum() + 1e-12)
+        ),
+    }
+    return sampler, stats

--- a/ignis_ml/src/utils/paths.py
+++ b/ignis_ml/src/utils/paths.py
@@ -1,0 +1,62 @@
+"""Data-root resolution so the big datasets/tiles/models can live on an
+external drive while the code stays in the repo.
+
+Precedence for the data root:
+  1. $IGNIS_DATA_ROOT           (e.g. /Volumes/T7/ignis-data)
+  2. <repo>/data               (default; same as before)
+
+Any config path that begins with "data/" is rebased onto the data root, so
+config.v4.yaml needs no edits to move to the external drive — just set the env
+var once:
+
+    export IGNIS_DATA_ROOT=/Volumes/<YourDrive>/ignis-data
+
+Models default to <data_root>/models unless $IGNIS_MODELS_ROOT is set, so the
+multi-GB checkpoints also land on the external drive.
+"""
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+# repo root = three levels up from this file: ignis_ml/src/utils/paths.py
+REPO_ROOT = Path(__file__).resolve().parents[3]
+
+
+def data_root() -> Path:
+    env = os.environ.get("IGNIS_DATA_ROOT")
+    return Path(env).expanduser().resolve() if env else (REPO_ROOT / "data")
+
+
+def models_root() -> Path:
+    env = os.environ.get("IGNIS_MODELS_ROOT")
+    if env:
+        return Path(env).expanduser().resolve()
+    # Keep models next to the data when an external data root is set, otherwise
+    # use the repo's models/ dir (where the deployed checkpoints already live).
+    if os.environ.get("IGNIS_DATA_ROOT"):
+        return data_root() / "models"
+    return REPO_ROOT / "models"
+
+
+def resolve_data_path(p: str | os.PathLike) -> Path:
+    """Rebase a config path onto the active data root.
+
+    'data/tssatfire_500m_T6' -> <data_root>/tssatfire_500m_T6
+    absolute paths are returned unchanged.
+    """
+    p = Path(p)
+    if p.is_absolute():
+        return p
+    parts = p.parts
+    if parts and parts[0] == "data":
+        return data_root().joinpath(*parts[1:]) if len(parts) > 1 else data_root()
+    # any other relative path resolves against the repo root
+    return (REPO_ROOT / p).resolve()
+
+
+def describe() -> str:
+    return (
+        f"data_root={data_root()}  models_root={models_root()}  "
+        f"(IGNIS_DATA_ROOT={'set' if os.environ.get('IGNIS_DATA_ROOT') else 'unset'})"
+    )

--- a/ignis_ml/tests/test_ingest_tssatfire.py
+++ b/ignis_ml/tests/test_ingest_tssatfire.py
@@ -1,0 +1,100 @@
+"""Phase 1 smoke tests — channel assembly, schema, no NaN/Inf, eval metrics.
+
+These run with no external dataset (synthetic FireStack) so they're safe in CI.
+Run:  python -m pytest ignis_ml/tests/test_ingest_tssatfire.py -q
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
+
+from ignis_ml.scripts.ingest_ts_satfire import (  # noqa: E402
+    V4_DYNAMIC_ORDER,
+    V4_STATIC_ORDER,
+    FireStack,
+    _assemble_dynamic,
+    _assemble_static,
+    _mean_u_for_window,
+)
+from ignis_ml.scripts import eval_historical as ev  # noqa: E402
+
+
+def _synthetic_fire(days: int = 8, h: int = 64, w: int = 64) -> FireStack:
+    rng = np.random.default_rng(0)
+    # Provide a subset of dynamic channels; gust must be derived, viirs zero-filled.
+    dynamic = {
+        "fire_t": (rng.random((days, h, w)) > 0.9).astype(np.float32),
+        "u": rng.normal(-7.0, 1.0, (days, h, w)).astype(np.float32),  # Santa-Ana
+        "v": rng.normal(1.0, 1.0, (days, h, w)).astype(np.float32),
+        "tempC": rng.normal(25.0, 3.0, (days, h, w)).astype(np.float32),
+        "q": rng.random((days, h, w)).astype(np.float32) * 0.01,
+        "precip": np.zeros((days, h, w), np.float32),
+        "erc": rng.random((days, h, w)).astype(np.float32) * 100,
+        "bi": rng.random((days, h, w)).astype(np.float32) * 200,
+        "ndvi": rng.random((days, h, w)).astype(np.float32),
+    }
+    static = {
+        "elev": rng.random((h, w)).astype(np.float32) * 2000,
+        "pdsi": rng.normal(0, 3, (h, w)).astype(np.float32),
+        "chili": rng.random((h, w)).astype(np.float32) * 255,
+        "water": np.zeros((h, w), np.float32),
+        "fuel1": rng.normal(0, 1, (h, w)).astype(np.float32),
+        "fuel2": rng.normal(0, 1, (h, w)).astype(np.float32),
+    }
+    return FireStack(
+        name="synthetic", dynamic=dynamic, static=static,
+        transform=None, height=h, width=w, ignition_lonlat=(-118.5, 34.0),
+    )
+
+
+def test_dynamic_assembly_shape_and_order():
+    fire = _synthetic_fire()
+    win = slice(0, 6)
+    x_dyn = _assemble_dynamic(fire, win)
+    assert x_dyn.shape == (6, len(V4_DYNAMIC_ORDER), 64, 64)
+    assert len(V4_DYNAMIC_ORDER) == 12
+    assert np.isfinite(x_dyn).all()
+    # viirs channels absent -> zero-filled
+    for name in ("viirs_i4", "viirs_i5"):
+        idx = V4_DYNAMIC_ORDER.index(name)
+        assert np.allclose(x_dyn[:, idx], 0.0)
+    # gust derived (non-zero where wind present)
+    g = x_dyn[:, V4_DYNAMIC_ORDER.index("gust")]
+    assert g.mean() > 0.0
+
+
+def test_static_assembly_shape_and_finite():
+    fire = _synthetic_fire()
+    x_stat = _assemble_static(fire)
+    assert x_stat.shape == (len(V4_STATIC_ORDER), 64, 64)
+    assert len(V4_STATIC_ORDER) == 9
+    assert np.isfinite(x_stat).all()
+
+
+def test_santa_ana_detection():
+    fire = _synthetic_fire()
+    x_dyn = _assemble_dynamic(fire, slice(0, 6))
+    assert _mean_u_for_window(x_dyn) < -5.0  # synthetic winds are Santa-Ana
+
+
+def test_eval_metrics_basic():
+    a = np.zeros((64, 64), np.float32)
+    b = np.zeros((64, 64), np.float32)
+    a[10:20, 10:20] = 1
+    b[10:20, 10:20] = 1
+    assert ev.iou(a, b) == pytest.approx(1.0)
+    assert ev.dice(a, b) == pytest.approx(1.0)
+    assert ev.csi(a, b) == pytest.approx(1.0)
+    assert ev.hausdorff_km(a, b) == pytest.approx(0.0)
+
+    c = np.zeros((64, 64), np.float32)
+    c[30:40, 30:40] = 1
+    assert ev.iou(a, c) == 0.0
+    assert ev.hausdorff_km(a, c) > 0.0

--- a/ignis_ml/train_v4.py
+++ b/ignis_ml/train_v4.py
@@ -1,0 +1,370 @@
+#!/usr/bin/env python3
+"""train_v4.py — self-contained v4 trainer (Santa-Ana retrain).
+
+Why a new file instead of editing train_nautilus.py:
+  * train_nautilus.py imports `src.utils.config` which is not in this repo
+    (the real Nautilus trainer lived in an unmounted folder), so it can't run
+    here as-is, AND
+  * it is mask-mode only — no delta target, no derived features, no Tversky.
+This trainer is the complete v4 path and depends only on modules that exist:
+  src/data/dataset.py, src/data/features.py, src/models/convlstm_unet.py,
+  src/training/v4_losses.py, src/training/v4_sampler.py, src/utils/paths.py.
+
+PRESS GO (after ingestion):  cd ignis_ml && python train_v4.py
+Data/tiles/models follow $IGNIS_DATA_ROOT (external drive) automatically.
+
+NOTE: requires a real torch + CUDA GPU + the ingested tiles to actually run.
+It is import/syntax-clean here; it has not been executed end-to-end (no GPU/data
+in this environment). Use --limit-files for a fast first sanity pass.
+"""
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import math
+import time
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Tuple
+
+import numpy as np
+import torch
+import torch.nn.functional as F
+from torch.amp import GradScaler, autocast
+from torch.utils.data import DataLoader
+
+from src.data.dataset import NpzTileDataset
+from src.models.convlstm_unet import ConvLSTMUNet, ARCH_VERSION
+from src.training.v4_losses import v4_total_loss
+from src.training.v4_sampler import build_santa_ana_sampler
+from src.utils.paths import data_root, models_root, resolve_data_path, describe
+
+
+# ----------------------------- config ------------------------------------
+def load_yaml(path: Path) -> Dict[str, Any]:
+    import yaml
+    with open(path) as f:
+        return yaml.safe_load(f)
+
+
+def cfg_get(d: Dict[str, Any], dotted: str, default=None):
+    cur: Any = d
+    for k in dotted.split("."):
+        if not isinstance(cur, dict) or k not in cur:
+            return default
+        cur = cur[k]
+    return cur
+
+
+# ----------------------------- helpers -----------------------------------
+def get_device() -> str:
+    if torch.cuda.is_available():
+        return "cuda"
+    if getattr(torch.backends, "mps", None) and torch.backends.mps.is_available():
+        return "mps"
+    return "cpu"
+
+
+def set_seed(seed: int):
+    import random
+    random.seed(seed); np.random.seed(seed); torch.manual_seed(seed)
+    if torch.cuda.is_available():
+        torch.cuda.manual_seed_all(seed)
+
+
+def collect_tiles(cfg: Dict[str, Any]) -> List[Path]:
+    """Glob npz tiles from every configured dataset, rebased to the data root."""
+    files: List[Path] = []
+    for name, ds in (cfg.get("datasets") or {}).items():
+        td = ds.get("tiles_dir")
+        if not td:
+            continue
+        p = resolve_data_path(td)
+        if p.is_dir():
+            found = sorted(p.glob("*.npz"))
+            print(f"[data] {name}: {len(found)} tiles in {p}")
+            files += found
+        else:
+            print(f"[data] {name}: tiles dir not found ({p}) — skipping")
+    return files
+
+
+def _dilate(y: torch.Tensor, px: int) -> torch.Tensor:
+    if px <= 0:
+        return y
+    k = 2 * px + 1
+    return F.max_pool2d(y, kernel_size=k, stride=1, padding=px)
+
+
+def base_bce_dice(logits, y, *, pos_weight, dice_lambda, dilate_px) -> torch.Tensor:
+    bce = F.binary_cross_entropy_with_logits(logits, y, pos_weight=pos_weight)
+    yd = _dilate(y, int(dilate_px))
+    p = torch.sigmoid(logits)
+    inter = (p * yd).sum(dim=(1, 2, 3))
+    dice = 1 - (2 * inter + 1e-6) / (p.sum(dim=(1, 2, 3)) + yd.sum(dim=(1, 2, 3)) + 1e-6)
+    return bce + dice_lambda * dice.mean()
+
+
+def resize_to_target(logits, y):
+    if logits.shape[-2:] != y.shape[-2:]:
+        logits = F.interpolate(logits, size=y.shape[-2:], mode="bilinear", align_corners=False)
+    return logits
+
+
+@torch.no_grad()
+def estimate_pos_prior(loader, max_batches=30) -> float:
+    pos = tot = 0.0
+    for i, batch in enumerate(loader):
+        y = batch[2]  # delta target
+        pos += float((y > 0.5).sum()); tot += float(y.numel())
+        if i + 1 >= max_batches:
+            break
+    return pos / max(tot, 1.0)
+
+
+@torch.no_grad()
+def eval_csi(model, loader, device, thresholds: List[float]) -> Tuple[float, float]:
+    """Return (best_threshold, best_CSI) over the val set."""
+    model.eval()
+    tp = {t: 0.0 for t in thresholds}; fp = dict(tp); fn = dict(tp)
+    for batch in loader:
+        x_d, x_s, y = batch[0].to(device), batch[1].to(device), batch[2].to(device)
+        logits = resize_to_target(model(x_d, x_s), y)
+        p = torch.sigmoid(logits)
+        for t in thresholds:
+            pb = (p >= t)
+            yb = (y >= 0.5)
+            tp[t] += float((pb & yb).sum())
+            fp[t] += float((pb & ~yb).sum())
+            fn[t] += float((~pb & yb).sum())
+    best_t, best_csi = thresholds[0], -1.0
+    for t in thresholds:
+        denom = tp[t] + fp[t] + fn[t]
+        csi = tp[t] / denom if denom > 0 else 0.0
+        if csi > best_csi:
+            best_csi, best_t = csi, t
+    return best_t, best_csi
+
+
+def export_calibration(model, loader, device, ckpt_path: Path, out_path: Path):
+    """Fit isotonic calibration on (raw_prob, observed) and save JSON.
+
+    Skips gracefully if scikit-learn is unavailable.
+    """
+    try:
+        from sklearn.isotonic import IsotonicRegression
+    except Exception:
+        print("[calib] scikit-learn not installed — skipping calibration export")
+        return
+    probs, obs = [], []
+    model.eval()
+    with torch.no_grad():
+        for i, batch in enumerate(loader):
+            x_d, x_s, y = batch[0].to(device), batch[1].to(device), batch[2].to(device)
+            p = torch.sigmoid(resize_to_target(model(x_d, x_s), y))
+            probs.append(p.flatten().cpu().numpy())
+            obs.append((y >= 0.5).flatten().cpu().numpy().astype(np.float32))
+            if i + 1 >= 40:
+                break
+    if not probs:
+        return
+    pr = np.concatenate(probs); ob = np.concatenate(obs)
+    iso = IsotonicRegression(out_of_bounds="clip").fit(pr, ob)
+    xs = np.linspace(0, 1, 101)
+    ys = iso.predict(xs)
+    sha = hashlib.sha256(ckpt_path.read_bytes()).hexdigest() if ckpt_path.exists() else None
+    out_path.write_text(json.dumps({
+        "method": "isotonic",
+        "model_sha256": sha,
+        "points": [[float(a), float(b)] for a, b in zip(xs, ys)],
+        "risk_breaks": [["low", 0.05], ["medium", 0.20], ["high", 0.50], ["extreme", 1.01]],
+    }, indent=2))
+    print(f"[calib] wrote {out_path}")
+
+
+# ------------------------------- main ------------------------------------
+def main(argv: Optional[List[str]] = None) -> int:
+    ap = argparse.ArgumentParser(description="IgnisAI v4 trainer")
+    ap.add_argument("--config", type=Path, default=Path(__file__).with_name("config.v4.yaml"))
+    ap.add_argument("--limit-files", type=int, default=0, help="cap tiles for a fast sanity run")
+    ap.add_argument("--epochs", type=int, default=0, help="override config epochs")
+    args = ap.parse_args(argv)
+
+    cfg = load_yaml(args.config)
+    print(f"[paths] {describe()}")
+    set_seed(int(cfg_get(cfg, "training.seed", 42)))
+    device = get_device()
+    use_amp = (device == "cuda") and bool(cfg_get(cfg, "training.mixed_precision", True))
+    print(f"[v4] device={device} amp={use_amp}")
+
+    dyn_order = cfg_get(cfg, "channels.dynamic_order")
+    stat_order = cfg_get(cfg, "channels.static_order")
+    seq_len = int(cfg_get(cfg, "training.seq_len", 6))
+    res_m = float(cfg_get(cfg, "grid.res_m", 500))
+
+    files = collect_tiles(cfg)
+    if args.limit_files:
+        files = files[: args.limit_files]
+    if not files:
+        print("[v4] no tiles found. Run ingestion first "
+              "(python -m ignis_ml.scripts.ingest_ts_satfire).")
+        return 1
+
+    rng = np.random.default_rng(int(cfg_get(cfg, "training.seed", 42)))
+    idx = np.arange(len(files)); rng.shuffle(idx)
+    n_val = max(1, int(len(files) * 0.15))
+    val_files = [files[i] for i in idx[:n_val]]
+    train_files = [files[i] for i in idx[n_val:]]
+    print(f"[v4] train={len(train_files)} val={len(val_files)}")
+
+    aug = cfg.get("augmentation", {})
+    ds_common = dict(
+        expected_dyn_order=dyn_order, expected_stat_order=stat_order,
+        seq_len=seq_len, res_m=res_m, normalize=True, fire_boost=5.0,
+        compute_slope_aspect=True,
+        derived_features_enable=bool(cfg_get(cfg, "features.derived.enable", True)),
+        derived_features_include=cfg_get(cfg, "features.derived.include", None),
+        days_since_fire_cap=cfg_get(cfg, "features.days_since_fire_cap", None),
+        target_mode="delta",
+    )
+    ds_tr = NpzTileDataset(
+        train_files, augment=True,
+        channel_dropout_p=float(aug.get("channel_dropout_p", 0.0)),
+        channel_dropout_exclude=aug.get("channel_dropout_exclude"),
+        gaussian_noise_std=float(aug.get("gaussian_noise_std", 0.0)),
+        temporal_dropout_p=float(aug.get("temporal_dropout_p", 0.0)),
+        **ds_common,
+    )
+    ds_va = NpzTileDataset(val_files, augment=False, **ds_common)
+
+    meta_dir = cfg_get(cfg, "datasets.tssatfire.meta_dir")
+    meta_dir = resolve_data_path(meta_dir) if meta_dir else None
+    sampler, sa_stats = build_santa_ana_sampler(
+        train_files, meta_dir=meta_dir,
+        santa_ana_boost=float(cfg_get(cfg, "training.sampling.santa_ana_boost", 5.0)),
+        seed=int(cfg_get(cfg, "training.seed", 42)),
+    )
+    print(f"[v4] sampler: {sa_stats}")
+
+    bs = int(cfg_get(cfg, "training.batch_size", 8))
+    nw = int(cfg_get(cfg, "training.num_workers", 4))
+    pin = (device == "cuda")
+    dl_tr = DataLoader(ds_tr, batch_size=bs, sampler=sampler, num_workers=nw,
+                       pin_memory=pin, persistent_workers=(nw > 0))
+    dl_va = DataLoader(ds_va, batch_size=bs, shuffle=False, num_workers=nw,
+                       pin_memory=pin, persistent_workers=(nw > 0))
+
+    # Infer channel counts from a real batch (derived features included).
+    first = next(iter(dl_tr))
+    x_d0, x_s0 = first[0], first[1]
+    Cd, Cs, tile = x_d0.shape[2], x_s0.shape[1], x_d0.shape[-1]
+    print(f"[v4] Cd={Cd} Cs={Cs} tile={tile} (arch={ARCH_VERSION})")
+
+    hidden = int(cfg_get(cfg, "training.hidden_channels", 64))
+    model = ConvLSTMUNet(
+        Cd=Cd, Cs=Cs, hidden=hidden,
+        drop=float(cfg_get(cfg, "training.drop_encoder", 0.10)),
+        drop_decoder=float(cfg_get(cfg, "training.drop_decoder", 0.15)),
+    ).to(device)
+    if device == "cuda":
+        model = model.to(memory_format=torch.channels_last)
+
+    prior = estimate_pos_prior(dl_tr)
+    pw = min(15.0, (1 - prior) / max(prior, 1e-5))
+    pos_weight = torch.tensor([pw], device=device)
+    print(f"[v4] delta pos prior={prior:.5f} pos_weight={pw:.2f}")
+
+    epochs = args.epochs or int(cfg_get(cfg, "training.epochs", 30))
+    warmup = int(cfg_get(cfg, "training.warmup_epochs", 5))
+    opt = torch.optim.AdamW(model.parameters(), lr=float(cfg_get(cfg, "training.lr", 8e-4)),
+                            weight_decay=float(cfg_get(cfg, "training.weight_decay", 5e-4)))
+
+    def lr_lambda(ep):
+        if ep < warmup:
+            return (ep + 1) / max(1, warmup)
+        prog = (ep - warmup) / max(1, epochs - warmup)
+        return 0.5 * (1 + math.cos(math.pi * min(max(prog, 0.0), 1.0)))
+    sch = torch.optim.lr_scheduler.LambdaLR(opt, lr_lambda)
+    scaler = GradScaler("cuda", enabled=use_amp) if device == "cuda" else None
+
+    dice_lambda = float(cfg_get(cfg, "training.loss.dice_weight", 0.6))
+    dilate_px = int(cfg_get(cfg, "training.loss.dice_dilate_px", 2))
+    tversky_cfg = cfg_get(cfg, "training.loss.tversky")
+    wind_cfg = cfg_get(cfg, "training.loss.wind_align")
+    fire_idx = dyn_order.index("fire_t")
+    u_idx, v_idx = dyn_order.index("u"), dyn_order.index("v")
+
+    sweep = cfg_get(cfg, "training.metrics.threshold_sweep", {"lo": 0.05, "hi": 0.5, "n": 46})
+    thresholds = list(np.linspace(sweep["lo"], sweep["hi"], int(sweep["n"])))
+
+    grad_clip = float(cfg_get(cfg, "training.grad_clip", 1.0))
+    early_stop = int(cfg_get(cfg, "training.early_stop", 6))
+    best_csi, best_t, patience = -1.0, thresholds[0], 0
+    out_dir = models_root(); out_dir.mkdir(parents=True, exist_ok=True)
+    ckpt_path = out_dir / f"convlstm_unet_{ARCH_VERSION}_delta_Cd{Cd}_Cs{Cs}_H{hidden}_T{seq_len}.pt"
+
+    print(f"[v4] training {epochs} epochs -> {ckpt_path}")
+    for ep in range(1, epochs + 1):
+        model.train(); t0 = time.time(); run = 0.0
+        for batch in dl_tr:
+            x_d = batch[0].to(device, non_blocking=True)
+            x_s = batch[1].to(device, non_blocking=True)
+            y = batch[2].to(device, non_blocking=True)            # delta target
+            # de-normalize wind ([0,1] from [-15,15]) -> m/s for wind-align
+            u_mean = x_d[:, :, u_idx].mean(dim=(1, 2, 3)) * 30.0 - 15.0
+            v_mean = x_d[:, :, v_idx].mean(dim=(1, 2, 3)) * 30.0 - 15.0
+            fire_last = x_d[:, -1, fire_idx:fire_idx + 1]         # [B,1,H,W]
+
+            opt.zero_grad(set_to_none=True)
+            with autocast("cuda", enabled=use_amp):
+                logits = resize_to_target(model(x_d, x_s), y)
+                base = base_bce_dice(logits, y, pos_weight=pos_weight,
+                                     dice_lambda=dice_lambda, dilate_px=dilate_px)
+                loss = v4_total_loss(
+                    logits, y, base_loss=base,
+                    tversky_cfg=tversky_cfg, wind_cfg=wind_cfg,
+                    fire_last=fire_last, u_mean=u_mean, v_mean=v_mean,
+                )
+            if scaler is not None:
+                scaler.scale(loss).backward()
+                scaler.unscale_(opt)
+                torch.nn.utils.clip_grad_norm_(model.parameters(), grad_clip)
+                scaler.step(opt); scaler.update()
+            else:
+                loss.backward()
+                torch.nn.utils.clip_grad_norm_(model.parameters(), grad_clip)
+                opt.step()
+            run += float(loss.item())
+        sch.step()
+
+        t, csi = eval_csi(model, dl_va, device, thresholds)
+        print(f"[v4] epoch {ep}/{epochs} loss={run/max(len(dl_tr),1):.4f} "
+              f"valCSI={csi:.3f}@{t:.2f} ({time.time()-t0:.0f}s)")
+
+        if csi > best_csi + 1e-4:
+            best_csi, best_t, patience = csi, t, 0
+            torch.save({
+                "state_dict": model.state_dict(),
+                "arch_version": ARCH_VERSION,
+                "cd": Cd, "cs": Cs, "tile_size": tile, "hidden": hidden,
+                "dyn_order": dyn_order, "stat_order": stat_order,
+                "target_mode": "delta",
+                "best_threshold": best_t, "val_csi": best_csi,
+                "santa_ana_stats": sa_stats,
+            }, ckpt_path)
+            print(f"  ✓ saved {ckpt_path.name} (CSI={best_csi:.3f}, th={best_t:.2f})")
+        else:
+            patience += 1
+            if patience >= early_stop:
+                print(f"[v4] early stop at epoch {ep} (best CSI={best_csi:.3f})")
+                break
+
+    # Calibration JSON keyed to the best checkpoint.
+    export_calibration(model, dl_va, device, ckpt_path,
+                       out_dir / f"calibration_{ARCH_VERSION}.json")
+    print(f"[v4] done. best CSI={best_csi:.3f}@{best_t:.2f}  ckpt={ckpt_path}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/models/CHANGELOG.md
+++ b/models/CHANGELOG.md
@@ -1,0 +1,35 @@
+# Model Changelog
+
+## v4 (in progress) — Santa-Ana-aware retrain
+
+Goal: produce a tight, directional fire-spread heatmap for Santa-Ana / WUI
+events (Palisades-class), where v3 fails. See `docs/v4-retraining-gameplan.md`
+and `docs/heatmap-diagnosis.md`.
+
+Changes vs v3:
+
+- **Data**: add TS-SatFire (2017–2021, includes Santa-Ana coastal fires) merged
+  with mNDWS. Ingestion: `ignis_ml/scripts/ingest_ts_satfire.py`.
+- **Channels**: dynamic 12 raw + 6 derived = 18 (add VIIRS I4/I5 thermal; move
+  erc/bi/ndvi to dynamic). static 9 (drop `impervious`, `population`, `fuel3` —
+  the urban shortcut features that mislocated v3).
+- **Loss**: actually apply Tversky (alpha=0.3, beta=0.7) — it was configured but
+  never wired into v3's loss. Add a wind-alignment regularizer (weight 0.1).
+- **Augmentation**: protect `u/v/gust/viirs_i4` from channel dropout (v3 zeroed
+  wind ~15% of the time); lower dropout 0.15→0.05.
+- **Sampling**: up-weight Santa-Ana fires 5× (`v4_sampler.build_santa_ana_sampler`).
+- **Threshold**: sweep 0.05–0.50 (delta operating point), add isotonic
+  calibration JSON.
+- **arch_version**: bump `v3` → `v4`.
+
+Expected: Palisades day-1 pushes SW (not urban-east); CSI on Santa-Ana holdout
+≥ 0.20; mean Hausdorff ≤ 5 km day 1.
+
+Known remaining gap: day-2 magnitude under-estimate on extreme wind events.
+
+## v3 — delta + derived features (deployed)
+
+`convlstm_unet_v3_delta_Cd13_Cs15_H64_T6_nautilus.pt`. ConvLSTM-UNet, delta
+target, 6 derived features. Trained on mNDWS only. CSI ≈ 0.235. Out of
+distribution for coastal Santa-Ana fires; under-weights wind (training dropout)
+and over-uses urban static features.

--- a/run_v4.sh
+++ b/run_v4.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+# run_v4.sh — one-command v4 retrain pipeline ("press go").
+#
+# Prereqs (one-time):
+#   1. Put data on the big drive:   export IGNIS_DATA_ROOT=/Volumes/<YourDrive>/ignis-data
+#   2. Download TS-SatFire into $IGNIS_DATA_ROOT/tssatfire_raw/
+#         kaggle datasets download -d z789456sx/ts-satfire -p "$IGNIS_DATA_ROOT/tssatfire_raw" --unzip
+#   3. Fill the TODO(dataset) band map in ignis_ml/scripts/ingest_ts_satfire.py
+#   4. pip install -r e2e/requirements.txt  (torch, rasterio, pyyaml, scikit-learn, pillow)
+#
+# Then just:   ./run_v4.sh
+set -euo pipefail
+cd "$(dirname "$0")"
+
+: "${IGNIS_DATA_ROOT:=$(pwd)/data}"
+export IGNIS_DATA_ROOT
+echo "==> IGNIS_DATA_ROOT=$IGNIS_DATA_ROOT"
+
+TILES_DIR="$IGNIS_DATA_ROOT/tssatfire_500m_T6"
+
+# 1) Ingest TS-SatFire -> tiles (skip if already populated)
+if [ -z "$(ls -A "$TILES_DIR" 2>/dev/null | grep -m1 '\.npz' || true)" ]; then
+  echo "==> [1/3] Ingesting TS-SatFire -> $TILES_DIR"
+  python -m ignis_ml.scripts.ingest_ts_satfire
+else
+  echo "==> [1/3] Tiles already present in $TILES_DIR — skipping ingestion"
+fi
+
+# 2) Train v4 (delta + derived + Tversky + wind-align + Santa-Ana sampler)
+echo "==> [2/3] Training v4"
+( cd ignis_ml && python train_v4.py )
+
+# 3) OOD eval vs observed perimeters (needs data/perimeters/*.geojson)
+echo "==> [3/3] OOD eval (optional — needs perimeters + a running tilesvc)"
+python -m ignis_ml.scripts.eval_historical --mode http \
+  --tilesvc "${TILE_SVC:-https://ignisai-tilesvc.onrender.com}" \
+  --out "$IGNIS_DATA_ROOT/models/eval/v4_eval.csv" || \
+  echo "   (eval skipped — add data/perimeters/*.geojson and/or a reachable tilesvc)"
+
+echo "==> done. Checkpoint + calibration are under: $(python -c 'import sys;sys.path.insert(0,"ignis_ml");from src.utils.paths import models_root;print(models_root())')"


### PR DESCRIPTION
- train_v4.py: complete trainer (delta + derived feats + Tversky + wind-align loss + Santa-Ana sampler) reading config.v4.yaml; no dep on missing src/utils/config.py. Old train_nautilus.py was mask-only and unrunnable.
- ingest_ts_satfire.py / eval_historical.py / mini-pipeline notebook / tests.
- dataset.py: channel_dropout_exclude so wind (u/v/gust) is never dropped (v3 bug).
- convlstm_unet.py: ARCH_VERSION v3 -> v4.
- src/utils/paths.py + IGNIS_DATA_ROOT: put 70-100GB data/tiles/models on an external drive with zero rewiring. docs/STORAGE.md.
- run_v4.sh one-command pipeline; v4 config/changelog/diagnosis docs.